### PR TITLE
Add history in checkout to fix showLastUpdateTime

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Needed for showLastUpdateTime to work
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'


### PR DESCRIPTION
# Description of change

Docusaurus fetches the history to get the `showLastUpdateTime`. I changed the checkout action so that it fetches the whole history.
Check [this.](https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested the wiki locally and tested that all external links work
