### PR TITLE
Fix - Megamenu doesn't fully go away

### DIFF
--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -20,10 +20,10 @@
   width: 100%;
   opacity: 0;
   visibility: hidden;
+  display: none;
   z-index: var(--ifm-z-index-dropdown);
   top: calc(100% - var(--ifm-navbar-padding-vertical) - 5px);
   left: 0;
-
   transition-property: opacity, visibility;
   transition-duration: var(--ifm-transition-fast);
   transition-timing-function: var(--ifm-transition-timing-default);
@@ -32,6 +32,7 @@
 .dropdown--show .dropdown__container {
   opacity: 1;
   visibility: visible;
+  display: block;
 }
 
 .dropdown__label {


### PR DESCRIPTION
# Description of change

Sometimes the megamenu disappears, but it is still clickable.  Attempt to fix that.
* Added display prop, it seems to work.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Locally

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
