### PR TITLE
Next attempt to fix deploy 

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test Build
         run: |
           if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --network-concurrency=1
           elif [ -e package-lock.json ]; then
           npm ci
           else
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --network-concurrency=1
           elif [ -e package-lock.json ]; then
           npm ci
           else


### PR DESCRIPTION
# Description of change

This PR adds the --network-concurrency flag to avoid the `ENOENT: no such file or directory` error due to poor network connectivity.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested in own repository


