### PR TITLE
Typo in the warning sign

### DIFF
--- a/internal/build/networks/iota-2.0.mdx
+++ b/internal/build/networks/iota-2.0.mdx
@@ -27,7 +27,7 @@ import Card from '/src/theme/Card';
   <div className='admonition-content'>
     <p>
       IOTA 2.0 runs on its own development network. Everything is highly
-      experimental and suggest to change.{' '}
+      experimental and subject to change.{' '}
     </p>
     <p>Also, tokens in IOTA 2.0 DevNet don't have value.</p>
   </div>


### PR DESCRIPTION
# Description of change

The yellow warning sign on top of the page reads "[...] suggest to change." when what was probably meant was "[...] **subject** to change.".

## Type of change

- Documentation Fix (typo)

## How the change has been tested

I read it. Twice ;)


