### PR TITLE
Fix old repo links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,13 +30,13 @@ This section guides you through reporting a bug. Following these guidelines help
 
 Please check the following list:
 
-- **Ensure the bug was not already reported** by searching on GitHub under [**Issues**](https://github.com/iota-community/iota-wiki/issues). If the bug has already been reported **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+- **Ensure the bug was not already reported** by searching on GitHub under [**Issues**](https://github.com/iota-wiki/iota-wiki/issues). If the bug has already been reported **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 **Note:** If you find a **Closed** issue that seems similar to what you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
 ### Submitting A Bug Report
 
-To report a bug, [open a new issue](https://github.com/iota-community/iota-wiki/issues/new), and be sure to include as many details as possible, using the template.
+To report a bug, [open a new issue](https://github.com/iota-wiki/iota-wiki/issues/new), and be sure to include as many details as possible, using the template.
 
 **Note:** Minor changes such as fixing a typo can but do not need an open issue.
 
@@ -54,11 +54,11 @@ This section guides you through suggesting a new feature or adding a new topic t
 
 ### Before suggesting a new feature
 
-**Ensure the feature or topic has not already been suggested** by searching on GitHub under [**Issues**](https://github.com/iota-community/iota-wiki/issues).
+**Ensure the feature or topic has not already been suggested** by searching on GitHub under [**Issues**](https://github.com/iota-wiki/iota-wiki/issues).
 
 ### Suggesting a new feature or topic
 
-To suggest a new feature/topic, [open a new issue](https://github.com/iota-community/iota-wiki/issues/new), using the suggestion template.
+To suggest a new feature/topic, [open a new issue](https://github.com/iota-wiki/iota-wiki/issues/new), using the suggestion template.
 
 </details>
 
@@ -72,7 +72,7 @@ This section guides you through adding a new feature or topic. Following these g
 
 ### Before adding a new feature/topic
 
-Check if there is already an [open issue](https://github.com/iota-community/iota-wiki/issues/) or [pull request (PR)](https://github.com/iota-community/iota-wiki/pulls), related to your feature/topic.
+Check if there is already an [open issue](https://github.com/iota-wiki/iota-wiki/issues/) or [pull request (PR)](https://github.com/iota-wiki/iota-wiki/pulls), related to your feature/topic.
 
 Otherwise, your feature may not be approved at all.
 
@@ -144,7 +144,7 @@ Once you have completed your contribution goes to the bottom of the edit page to
 
 To keep our WIKI Project organized and help everyone understand the current state of work that's going on, we decided to use a Kanban Style Project Board. Everything related to content creation should be represented in this board. You will find it under the projects tab:
 
-https://github.com/iota-community/iota-wiki/projects
+https://github.com/iota-wiki/iota-wiki/projects
 
 ![image](https://user-images.githubusercontent.com/77154511/126052298-4c8fbb3f-cb39-41d5-93d4-13c3b4e4626d.png)
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 <div align="center">
 
   <!-- PROJECT SHIELDS -->
-
-[![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
-[![Gitpod][gitpod-shield]][gitpod-url]
+  [![Contributors][contributors-shield]][contributors-url]
+  [![Forks][forks-shield]][forks-url]
+  [![Stargazers][stars-shield]][stars-url]
+  [![Issues][issues-shield]][issues-url]
+  [![Gitpod][gitpod-shield]][gitpod-url]
 
   <!-- PROJECT LOGO -->
   <p>
@@ -30,7 +29,6 @@
 </div>
 
 <!-- TABLE OF CONTENTS -->
-
 ## Table of Contents
 
 - [About The Project](#about-the-project)
@@ -42,7 +40,6 @@
 - [Contact](#contact)
 
 <!-- ABOUT THE PROJECT -->
-
 ## About The Project
 
 The IOTA Wiki is a central hub for entering into the IOTA ecosystem. A community driven initiative to provide an up-to-date collection of introductions and further reading about the technology, the teams, the community, and everything in between. So anyone can learn how to build, adopt, and engage with IOTA, all in one space.
@@ -52,7 +49,6 @@ The IOTA Wiki is a central hub for entering into the IOTA ecosystem. A community
 The IOTA Wiki is built using [TypeScript](https://www.typescriptlang.org/), [ReactJS](https://reactjs.org/) and [Docusaurus v2.0](https://docusaurus.io/).
 
 <!-- GETTING STARTED -->
-
 ## Getting Started
 
 ### Prerequisites
@@ -72,7 +68,6 @@ The IOTA Wiki is built using [TypeScript](https://www.typescriptlang.org/), [Rea
 4. Start the local development server with `yarn start` to preview a minimal Wiki or with `yarn start:all` to preview the entire Wiki. Alternatively you can use the `CONTENT` environment variable to select the content you want to include in the preview. It accepts a list of glob patterns relative to the `content` subdirectory (i.e. `CONTENT=identity.rs/*/documentation yarn start` would give you a minimal Wiki with only `identity.rs` documentation included).
 
 <!-- CONTRIBUTING -->
-
 ## Contributing
 
 The IOTA Wiki is maintained by the community. We will review all issues and pull requests posted to this repository. If you notice any mistakes, or feel something is missing, feel free to create an issue to discuss with the team or directly create a pull request with suggestions. Here is a basic workflow to open a pull request:
@@ -93,7 +88,6 @@ You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a s
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][gitpod-url]
 
 <!-- CONTACT -->
-
 ## Contact
 
 Phylo - [Phyloiota](https://github.com/Phyloiota) - Phylo [Community DAO - lets go!]#2233  

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 <div align="center">
 
   <!-- PROJECT SHIELDS -->
-  [![Contributors][contributors-shield]][contributors-url]
-  [![Forks][forks-shield]][forks-url]
-  [![Stargazers][stars-shield]][stars-url]
-  [![Issues][issues-shield]][issues-url]
-  [![Gitpod][gitpod-shield]][gitpod-url]
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![Gitpod][gitpod-shield]][gitpod-url]
 
   <!-- PROJECT LOGO -->
   <p>
@@ -21,14 +22,15 @@
     <a href="https://wiki.iota.org"><strong>EXPLORE THE WIKI</strong></a>
   </p>
   <p>
-    <a href="https://github.com/iota-community/iota-Wiki/issues">Report Error</a>
+    <a href="https://github.com/iota-wiki/iota-wiki/issues">Report Error</a>
     ·
-    <a href="https://github.com/iota-community/iota-Wiki/issues">Request Topic</a>
+    <a href="https://github.com/iota-wiki/iota-wiki/issues">Request Topic</a>
   </p>
 
 </div>
 
 <!-- TABLE OF CONTENTS -->
+
 ## Table of Contents
 
 - [About The Project](#about-the-project)
@@ -39,8 +41,8 @@
 - [Contributing](#contributing)
 - [Contact](#contact)
 
-
 <!-- ABOUT THE PROJECT -->
+
 ## About The Project
 
 The IOTA Wiki is a central hub for entering into the IOTA ecosystem. A community driven initiative to provide an up-to-date collection of introductions and further reading about the technology, the teams, the community, and everything in between. So anyone can learn how to build, adopt, and engage with IOTA, all in one space.
@@ -50,6 +52,7 @@ The IOTA Wiki is a central hub for entering into the IOTA ecosystem. A community
 The IOTA Wiki is built using [TypeScript](https://www.typescriptlang.org/), [ReactJS](https://reactjs.org/) and [Docusaurus v2.0](https://docusaurus.io/).
 
 <!-- GETTING STARTED -->
+
 ## Getting Started
 
 ### Prerequisites
@@ -60,7 +63,7 @@ The IOTA Wiki is built using [TypeScript](https://www.typescriptlang.org/), [Rea
 
 ### Local Development
 
-1. Clone the repository by running `git clone https://github.com/iota-community/iota-wiki.git` and go to the directory with `cd iota-wiki`.
+1. Clone the repository by running `git clone https://github.com/iota-wiki/iota-wiki.git` and go to the directory with `cd iota-wiki`.
 
 2. Run `git submodule update --init --recursive` to check out the project submodules. Optionally you can add the `--remote` flag to get the latest changes.
 
@@ -69,6 +72,7 @@ The IOTA Wiki is built using [TypeScript](https://www.typescriptlang.org/), [Rea
 4. Start the local development server with `yarn start` to preview a minimal Wiki or with `yarn start:all` to preview the entire Wiki. Alternatively you can use the `CONTENT` environment variable to select the content you want to include in the preview. It accepts a list of glob patterns relative to the `content` subdirectory (i.e. `CONTENT=identity.rs/*/documentation yarn start` would give you a minimal Wiki with only `identity.rs` documentation included).
 
 <!-- CONTRIBUTING -->
+
 ## Contributing
 
 The IOTA Wiki is maintained by the community. We will review all issues and pull requests posted to this repository. If you notice any mistakes, or feel something is missing, feel free to create an issue to discuss with the team or directly create a pull request with suggestions. Here is a basic workflow to open a pull request:
@@ -89,6 +93,7 @@ You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a s
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][gitpod-url]
 
 <!-- CONTACT -->
+
 ## Contact
 
 Phylo - [Phyloiota](https://github.com/Phyloiota) - Phylo [Community DAO - lets go!]#2233  
@@ -107,13 +112,13 @@ Feel free to support our work:
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
-[contributors-shield]: https://img.shields.io/github/contributors/iota-community/iota-Wiki.svg?style=for-the-badge
-[contributors-url]: https://github.com/iota-community/iota-Wiki/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/iota-community/iota-Wiki.svg?style=for-the-badge
-[forks-url]: https://github.com/iota-community/iota-Wiki/network/members
-[stars-shield]: https://img.shields.io/github/stars/iota-community/iota-Wiki.svg?style=for-the-badge
-[stars-url]: https://github.com/iota-community/iota-Wiki/stargazers
-[issues-shield]: https://img.shields.io/github/issues/iota-community/iota-Wiki.svg?style=for-the-badge
-[issues-url]: https://github.com/iota-community/iota-Wiki/issues
+[contributors-shield]: https://img.shields.io/github/contributors/iota-wiki/iota-wiki.svg?style=for-the-badge
+[contributors-url]: https://github.com/iota-wiki/iota-wiki/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/iota-wiki/iota-wiki.svg?style=for-the-badge
+[forks-url]: https://github.com/iota-wiki/iota-wiki/network/members
+[stars-shield]: https://img.shields.io/github/stars/iota-wiki/iota-wiki.svg?style=for-the-badge
+[stars-url]: https://github.com/iota-wiki/iota-wiki/stargazers
+[issues-shield]: https://img.shields.io/github/issues/iota-wiki/iota-wiki.svg?style=for-the-badge
+[issues-url]: https://github.com/iota-wiki/iota-wiki/issues
 [gitpod-shield]: https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod&style=for-the-badge
 [gitpod-url]: https://gitpod.io/#https://github.com/iota-community/iota-Wiki

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -326,7 +326,7 @@ module.exports = {
             },
             {
               label: 'Github',
-              href: 'https://github.com/iota-community/iota-wiki',
+              href: 'https://github.com/iota-wiki/iota-wiki',
             },
             {
               label: 'Docusaurus',
@@ -426,7 +426,7 @@ module.exports = {
         sidebarPath: require.resolve('./internal/learn/sidebars.ts'),
 
         // General config
-        editUrl: 'https://github.com/iota-community/iota-wiki/edit/main/',
+        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
         remarkPlugins: [
           require('remark-code-import'),
           require('remark-import-partial'),
@@ -443,7 +443,7 @@ module.exports = {
         sidebarPath: require.resolve('./content/wallets/sidebars.ts'),
 
         // General config
-        editUrl: 'https://github.com/iota-community/iota-wiki/edit/main/',
+        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
         remarkPlugins: [
           require('remark-code-import'),
           require('remark-import-partial'),
@@ -460,7 +460,7 @@ module.exports = {
         sidebarPath: require.resolve('./content/networks/sidebars.ts'),
 
         // General config
-        editUrl: 'https://github.com/iota-community/iota-wiki/edit/main/',
+        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
         remarkPlugins: [
           require('remark-code-import'),
           require('remark-import-partial'),
@@ -478,7 +478,7 @@ module.exports = {
         sidebarPath: require.resolve('./content/nodes/sidebars.ts'),
 
         // General config
-        editUrl: 'https://github.com/iota-community/iota-wiki/edit/main/',
+        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
         remarkPlugins: [
           require('remark-code-import'),
           require('remark-import-partial'),
@@ -495,7 +495,7 @@ module.exports = {
         sidebarPath: require.resolve('./content/research/sidebars.ts'),
 
         // General config
-        editUrl: 'https://github.com/iota-community/iota-wiki/edit/main/',
+        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
         remarkPlugins: [
           require('remark-code-import'),
           require('remark-import-partial'),

--- a/internal/learn/contribute-to-wiki/how_tos/create_an_issue.md
+++ b/internal/learn/contribute-to-wiki/how_tos/create_an_issue.md
@@ -1,45 +1,46 @@
 ---
 description: We value your input.  Please take your time to create an issue to help improve the wiki.
 tags:
-- create issue
-- create bug
-- request feature
-- request topic
-- contribute
-- update
+  - create issue
+  - create bug
+  - request feature
+  - request topic
+  - contribute
+  - update
 image: /img/iota-wiki.png
 ---
+
 # Create an Issue
 
-As any GitHub repository, the wiki has associated [issues](https://github.com/iota-community/iota-wiki/issues).  You can 
+As any GitHub repository, the wiki has associated [issues](https://github.com/iota-wiki/iota-wiki/issues). You can
 create the following issue types.
 
 ## Bug Report
 
-You can 
-[create a bug report](https://github.com/iota-community/iota-wiki/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
-to let the wiki team know that something is wrong. Some examples of bug reports are dead links, Misaligned texts or 
+You can
+[create a bug report](https://github.com/iota-wiki/iota-wiki/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+to let the wiki team know that something is wrong. Some examples of bug reports are dead links, Misaligned texts or
 buttons, partially visible elements, missing buttons or sections, and typos.
 
-It is important that you provide all the steps you followed so whoever works on the bug is able to reproduce it. You 
-should also provide details as to what device, browser and OS you were using as these may be relevant.  
+It is important that you provide all the steps you followed so whoever works on the bug is able to reproduce it. You
+should also provide details as to what device, browser and OS you were using as these may be relevant.
 
 ## Request a Feature
 
-You can 
-[request a feature](https://github.com/iota-community/iota-wiki/issues/new?assignees=&labels=feature&template=feature_request.md&title=)
-to let the wiki team know what you would like them to implement to the wiki. Some examples of features are implementing 
+You can
+[request a feature](https://github.com/iota-wiki/iota-wiki/issues/new?assignees=&labels=feature&template=feature_request.md&title=)
+to let the wiki team know what you would like them to implement to the wiki. Some examples of features are implementing
 an image gallery, changing a components behaviour or adding support for a new media type.
 
-If you want your feature request to be successful, you should provide as much detail as possible so whoever works on it 
-can understand what you want properly.  Ideally, you should provide some form of solution rather than just raise a 
+If you want your feature request to be successful, you should provide as much detail as possible so whoever works on it
+can understand what you want properly. Ideally, you should provide some form of solution rather than just raise a
 problem. However, if you don't know how to resolve the issue, but you managed to identify it, this is also helpful.
 
 ## Request a Topic
 
-You can 
-[request a topic](https://github.com/iota-community/iota-wiki/issues/new?assignees=&labels=documentation&template=topic-request.md&title=)
-to the wiki team know that you'd like to add a 
+You can
+[request a topic](https://github.com/iota-wiki/iota-wiki/issues/new?assignees=&labels=documentation&template=topic-request.md&title=)
+to the wiki team know that you'd like to add a
 [topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics#about-topics)
 to the wiki repository. Topics can be managed by the repository admins, and are used to classify the repository. Helpful
 topics to classify a repository include the repository's intended purpose, subject area, community, or language.


### PR DESCRIPTION
# Description of change

Replace any links to `iota-community/iota-wiki` to `iota-wiki/iota-wiki`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
