### PR TITLE
Add hint to install typescript package on @iota/client installation

### DIFF
--- a/content/tutorials/single-page-tutorials/send-iota-tokens-with-javascript.md
+++ b/content/tutorials/single-page-tutorials/send-iota-tokens-with-javascript.md
@@ -31,6 +31,12 @@ Next you need to install the [iota client library](https://github.com/iotaledger
 npm i @iota/client
 ```
 
+When the previous call failed with `'tsc' is not recognized as an internal or external command, operable program or batch file.` it could help to install the typescript package globally by running:
+
+```bash
+npm install typescript@latest -g
+``` 
+
 ## 1. Create and save your seed.
 
 Create a new directory, a new file called `create_seed.js` and add the content below:


### PR DESCRIPTION
# Description of change

A hint how to install TypeScript package which was not found on my development system by `npm`.

## Links to any relevant issues

none

## Type of change

- Documentation Enhancement

## How the change has been tested

Hint is directly used on the local development system.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
