### PR TITLE
Update client lib links

### DIFF
--- a/next/develop/nodes/explanations/nodes_101.md
+++ b/next/develop/nodes/explanations/nodes_101.md
@@ -70,7 +70,7 @@ Nodes come with two sets of low-level APIs:
 
 :::note
 
-Developers do not need to communicate with nodes using a mentioned low-level API. Developers can leverage the [iota client libraries](/iota.rs/develop/libraries/overview) that provide a high-level abstraction to all features IOTA nodes provide, either on HTTP API level or Event API level.
+Developers do not need to communicate with nodes using a mentioned low-level API. Developers can leverage the [iota client libraries](/iota.rs/libraries/overview) that provide a high-level abstraction to all features IOTA nodes provide, either on HTTP API level or Event API level.
 
 :::
 

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -41,12 +41,12 @@ module.exports = {
             {
                 label: 'Client',
                 type: 'link',
-                href: '/iota.rs/develop/welcome',
+                href: '/iota.rs/welcome',
             },
             {
                 label: 'Wallet.rs',
                 type: 'link',
-                href: '/wallet.rs/develop/welcome',
+                href: '/wallet.rs/welcome',
             },
             {
                 label: 'Client Typescript',

--- a/next/develop/welcome.md
+++ b/next/develop/welcome.md
@@ -11,8 +11,8 @@ Welcome to the Developer Section. Here you will find all information to start de
     - [WASP CLI](/smart-contracts/guide/chains_and_nodes/wasp-cli)
     - [Schema Tool](/smart-contracts/guide/schema)
 - Libraries
-    - [Client.rs](/iota.rs/develop/welcome)
-    - [Wallet.rs](/wallet.rs/develop/welcome)
+    - [Client.rs](/iota.rs/welcome)
+    - [Wallet.rs](/wallet.rs/welcome)
     - [Client.js](/iotajs/welcome)
     - [Stronghold](/stronghold.rs/welcome)
 - Node Software

--- a/shimmer/develop/nodes/explanations/nodes_101.md
+++ b/shimmer/develop/nodes/explanations/nodes_101.md
@@ -70,7 +70,7 @@ Nodes come with two sets of low-level APIs:
 
 :::note
 
-Developers do not need to communicate with nodes using a mentioned low-level API. Developers can leverage the [iota client libraries](/iota.rs/develop/libraries/overview) that provide a high-level abstraction to all features IOTA nodes provide, either on HTTP API level or Event API level.
+Developers do not need to communicate with nodes using a mentioned low-level API. Developers can leverage the [iota client libraries](/iota.rs/libraries/overview) that provide a high-level abstraction to all features IOTA nodes provide, either on HTTP API level or Event API level.
 
 :::
 

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -41,12 +41,12 @@ module.exports = {
             {
                 label: 'Client',
                 type: 'link',
-                href: '/iota.rs/develop/welcome',
+                href: '/iota.rs/welcome',
             },
             {
                 label: 'Wallet.rs',
                 type: 'link',
-                href: '/wallet.rs/develop/welcome',
+                href: '/wallet.rs/welcome',
             },
             {
                 label: 'Client Typescript',

--- a/shimmer/develop/welcome.md
+++ b/shimmer/develop/welcome.md
@@ -11,8 +11,8 @@ Welcome to the Developer Section. Here you will find all information to start de
     - [WASP CLI](/smart-contracts/guide/chains_and_nodes/wasp-cli)
     - [Schema Tool](/smart-contracts/guide/schema)
 - Libraries
-    - [Client.rs](/iota.rs/develop/welcome)
-    - [Wallet.rs](/wallet.rs/develop/welcome)
+    - [Client.rs](/iota.rs/welcome)
+    - [Wallet.rs](/wallet.rs/welcome)
     - [Client.js](/iotajs/welcome)
     - [Stronghold](/stronghold.rs/welcome)
 - Node Software

--- a/src/components/next/HomeLayout/CoreLibrariesSection.tsx
+++ b/src/components/next/HomeLayout/CoreLibrariesSection.tsx
@@ -36,33 +36,33 @@ const LibrariesSection: FC = () => (
           </div>
           <Languages
             languages={{
-              Rust: '/iota.rs/develop/libraries/rust/getting_started',
-              NodeJS: '/iota.rs/develop/libraries/nodejs/getting_started',
-              Python: '/iota.rs/develop/libraries/python/getting_started',
-              Java: '/iota.rs/develop/libraries/java/getting_started',
+              Rust: '/iota.rs/libraries/rust/getting_started',
+              NodeJS: '/iota.rs/libraries/nodejs/getting_started',
+              Python: '/iota.rs/libraries/python/getting_started',
+              Java: '/iota.rs/libraries/java/getting_started',
             }}
           />
         </div>
         <h3 className='libraries__header'>Client</h3>
         <ul className='libraries__features'>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/examples/get_info'>
+            <Link to='/iota.rs/examples/get_info'>
               Interact with the IOTA network
             </Link>
           </li>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/examples/data_message'>
+            <Link to='/iota.rs/examples/data_message'>
               Send a data message
             </Link>
           </li>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/explanations/messages_payloads_and_transactions'>
+            <Link to='/iota.rs/explanations/messages_payloads_and_transactions'>
               Learn about transactions
             </Link>
           </li>
         </ul>
         <Link
-          to='/iota.rs/develop/welcome'
+          to='/iota.rs/welcome'
           className='libraries__button button button--outline button--primary'
         >
           Get started
@@ -77,9 +77,9 @@ const LibrariesSection: FC = () => (
           </div>
           <Languages
             languages={{
-              Rust: '/wallet.rs/develop/libraries/rust/getting_started',
-              NodeJS: '/wallet.rs/develop/libraries/nodejs/getting_started',
-              Python: '/wallet.rs/develop/libraries/python/getting_started',
+              Rust: '/wallet.rs/libraries/rust/getting_started',
+              NodeJS: '/wallet.rs/libraries/nodejs/getting_started',
+              Python: '/wallet.rs/libraries/python/getting_started',
             }}
           />
         </div>
@@ -102,7 +102,7 @@ const LibrariesSection: FC = () => (
           </li>
         </ul>
         <Link
-          to='/wallet.rs/develop/welcome'
+          to='/wallet.rs/welcome'
           className='libraries__button button button--outline button--primary'
         >
           Integrate a wallet

--- a/src/components/shimmer/HomeLayout/CoreLibrariesSection.tsx
+++ b/src/components/shimmer/HomeLayout/CoreLibrariesSection.tsx
@@ -36,33 +36,33 @@ const LibrariesSection: FC = () => (
           </div>
           <Languages
             languages={{
-              Rust: '/iota.rs/develop/libraries/rust/getting_started',
-              NodeJS: '/iota.rs/develop/libraries/nodejs/getting_started',
-              Python: '/iota.rs/develop/libraries/python/getting_started',
-              Java: '/iota.rs/develop/libraries/java/getting_started',
+              Rust: '/iota.rs/libraries/rust/getting_started',
+              NodeJS: '/iota.rs/libraries/nodejs/getting_started',
+              Python: '/iota.rs/libraries/python/getting_started',
+              Java: '/iota.rs/libraries/java/getting_started',
             }}
           />
         </div>
         <h3 className='libraries__header'>Client</h3>
         <ul className='libraries__features'>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/examples/get_info'>
+            <Link to='/iota.rs/examples/get_info'>
               Interact with the IOTA network
             </Link>
           </li>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/examples/data_message'>
+            <Link to='/iota.rs/examples/data_message'>
               Send a data message
             </Link>
           </li>
           <li className='libraries__feature'>
-            <Link to='/iota.rs/develop/explanations/messages_payloads_and_transactions'>
+            <Link to='/iota.rs/explanations/messages_payloads_and_transactions'>
               Learn about transactions
             </Link>
           </li>
         </ul>
         <Link
-          to='/iota.rs/develop/welcome'
+          to='/iota.rs/welcome'
           className='libraries__button button button--outline button--primary'
         >
           Get started
@@ -77,9 +77,9 @@ const LibrariesSection: FC = () => (
           </div>
           <Languages
             languages={{
-              Rust: '/wallet.rs/develop/libraries/rust/getting_started',
-              NodeJS: '/wallet.rs/develop/libraries/nodejs/getting_started',
-              Python: '/wallet.rs/develop/libraries/python/getting_started',
+              Rust: '/wallet.rs/libraries/rust/getting_started',
+              NodeJS: '/wallet.rs/libraries/nodejs/getting_started',
+              Python: '/wallet.rs/libraries/python/getting_started',
             }}
           />
         </div>
@@ -102,7 +102,7 @@ const LibrariesSection: FC = () => (
           </li>
         </ul>
         <Link
-          to='/wallet.rs/develop/welcome'
+          to='/wallet.rs/welcome'
           className='libraries__button button button--outline button--primary'
         >
           Integrate a wallet


### PR DESCRIPTION
# Description of change

For wiki v3 we don't need develop subpaths anymore.
As https://github.com/iotaledger/wallet.rs/pull/1466 and https://github.com/iotaledger/iota.rs/pull/1277 are merged we can remove develop from our links too

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
