### PR TITLE
Remove tmp redirects

### DIFF
--- a/docusaurus-shimmer.config.js
+++ b/docusaurus-shimmer.config.js
@@ -325,22 +325,8 @@ module.exports = {
       '@docusaurus/plugin-client-redirects',
       {
         createRedirects(existingPath) {
-          if (existingPath.includes('/iota.rs/develop')) {
-            return [existingPath.replace('/iota.rs/develop', '/iota.rs')];
-          }
-          if (existingPath.includes('/wallet.rs/develop')) {
-            return [existingPath.replace('/wallet.rs/develop', '/wallet.rs')];
-          }
-          if (existingPath.includes('/hornet/develop')) {
-            return [existingPath.replace('/hornet/develop', '/hornet')];
-          }
           if (existingPath.includes('/chronicle/develop')) {
             return [existingPath.replace('/chronicle/develop', '/chronicle')];
-          }
-          if (existingPath.includes('/introduction/develop')) {
-            return [
-              existingPath.replace('/introduction/develop', '/introduction'),
-            ];
           }
           return undefined; // Return a falsy value: no redirect created
         },


### PR DESCRIPTION
# Description of change

As we removed `develop` subpath we don't need this tmp redirects anymore

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
