### PR TITLE
Fix Shimmer explorer link on the landing page

### DIFF
--- a/src/components/shimmer/HomeLayout/index.tsx
+++ b/src/components/shimmer/HomeLayout/index.tsx
@@ -295,7 +295,7 @@ export default function HomeLayout() {
               </div>
             </Link>
             <Link
-              to='https://explorer.shimmer.network/testnet'
+              to='https://explorer.shimmer.network/shimmer'
               className='further__card'
             >
               <div className='further__section'>


### PR DESCRIPTION
# Description of change

Link pointed to the testnet instead of Shimmer network.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Local Wiki build.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
