### PR TITLE
Prevent indexing of the Next pages

### DIFF
--- a/docusaurus-next.config.js
+++ b/docusaurus-next.config.js
@@ -8,6 +8,7 @@ module.exports = {
   tagline: 'Unreleased documentation',
   url: 'https://wiki.iota.org',
   baseUrl: '/next/',
+  noIndex: true,
   onBrokenLinks: 'log',
   onBrokenMarkdownLinks: 'log',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
# Description of change

Next is currently indexed by search engines, which is not what we want as it is documentation in development. Setting `noIndex` adds `<meta name="robots" content="noindex, nofollow">` to every page generated by the Next configuration, which tells search engines to not index those pages.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Not tested

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
