### PR TITLE
Mention Java bindings in wallet card

### DIFF
--- a/src/components/next/HomeLayout/CoreLibrariesSection.tsx
+++ b/src/components/next/HomeLayout/CoreLibrariesSection.tsx
@@ -80,6 +80,7 @@ const LibrariesSection: FC = () => (
               Rust: '/wallet.rs/getting_started/rust',
               NodeJS: '/wallet.rs/getting_started/nodejs',
               Python: '/wallet.rs/getting_started/python',
+              Java: '/wallet.rs/getting_started/java',
             }}
           />
         </div>

--- a/src/components/shimmer/HomeLayout/CoreLibrariesSection.tsx
+++ b/src/components/shimmer/HomeLayout/CoreLibrariesSection.tsx
@@ -80,6 +80,7 @@ const LibrariesSection: FC = () => (
               Rust: '/wallet.rs/getting_started/rust',
               NodeJS: '/wallet.rs/getting_started/nodejs',
               Python: '/wallet.rs/getting_started/python',
+              Java: '/wallet.rs/getting_started/java',
             }}
           />
         </div>


### PR DESCRIPTION
# Description of change

As Java bindings are no ready for wallet.rs (Thanks @samuel-rufi ), I added them to our landing page cards

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
