### PR TITLE
Update wallet setup tutorial

### DIFF
--- a/tutorials/single-page-tutorials/wallet-setup.md
+++ b/tutorials/single-page-tutorials/wallet-setup.md
@@ -203,15 +203,17 @@ async function run() {
     console.log(account, '\n');
 ```
 
-#### 3. Create address
+#### 3. Return account address
 
-This step creates a new address in your account.
+Every newly created Stronghold account has one address to receive funds at. This part of the function gets the address from the account and logs it out on your console.
 
 ```javascript
-    // Generate a new address for your account
-    const address = await account.generateAddress();
-    console.log(consoleColor, `${accountName}'s new address:`);
-    console.log(address.address, '\n');
+    // Right after account creation, there should only be one address returned at keyIndex = 0
+    await account.sync();
+    const address = await account.addresses();
+
+    console.log(consoleColor, `${accountName}'s Address:`);
+    console.log(address, '\n');
 
   } catch (error) {
     console.log('Error: ', error);
@@ -235,7 +237,7 @@ Stronghold will create a new wallet database folder, `<accountName>-database`, a
 The console output should look similar to this:
 
 ```json
-<account_name>'s account:
+<account_name>'s Account:
 Account {
   meta: {
     index: 0,
@@ -254,11 +256,18 @@ Account {
   messageHandler: MessageHandler { messageHandler: [External: 277668a8e40] }
 }
 
-<account_name>'s new address:
-<your_new_address>
+<account_name>'s Address:
+[
+  {
+    address: 'rms1qqrmnqwysw6y7n0lhyju39p68fwwdv3a4m3khh0paczh2wft2wy853pmqmz',
+    keyIndex: 0,
+    internal: false,
+    used: false
+  }
+]
 ```
 
-You can see your new account and the generated address, which you will use to receive funds from the faucet. Before you request funds, let's check your account balance.
+You can see your new account and its associated address, which you will use to receive funds from the faucet. Before you request funds, let's check your account balance.
 
 ---
 
@@ -308,16 +317,20 @@ async function run() {
     const account = await manager.getAccount(accountName);
 ```
 
-#### 3. Get balance
+#### 3. Return account address(es) and balance
 
-This script will synchronize your account and fetch the balance for the imported account.
+This script will synchronize your account and fetch its address(es) and balance.
 
 ```javascript
     // Always sync before getting the account balance
     await account.sync();
     const balance = await account.getBalance();
+    const addresses = await account.addresses();
 
-    console.log(consoleColor, `${accountName}'s Balance:`);
+    console.log(consoleColor, `${accountName}'s Address(es):`);
+    console.log(addresses, '\n');
+
+    console.log(consoleColor, `${accountName}'s Total Balance:`);
     console.log(balance, '\n');
 
   } catch (error) {
@@ -337,10 +350,20 @@ You can now run the `check-balance.js` script and check the console output:
 node check-balance.js
 ```
 
-If you [created a new mnemonic seed phrase](#create-mnemonic-script) at the beginning of this tutorial, you should see an entirely empty balance on your account.
+If you [created a new mnemonic seed phrase](#create-mnemonic-script) at the beginning of this tutorial, you should see exactly one address and an entirely empty balance on your account.
 
 ```json
-<Account Name>'s Balance:
+<Account Name>'s Address(es):
+[
+  {
+    address: 'rms1qqrmnqwysw6y7n0lhyju39p68fwwdv3a4m3khh0paczh2wft2wy853pmqmz',
+    keyIndex: 0,
+    internal: false,
+    used: false
+  }
+]
+
+<Account Name>'s Total Balance:
 {
   baseCoin: { total: '0', available: '0' },
   requiredStorageDeposit: '0',
@@ -447,7 +470,17 @@ node check-balance.js
 If the faucet successfully transferred testnet tokens to your address, your balance should look similar to the content below. If the total balance for the `baseCoin` is still 0, repeat the process of running the `check-balance.js` script since it might take a little time for the funds to be transferred.
 
 ```json
-<account_name>'s Balance:
+<Account Name>'s Address(es):
+[
+  {
+    address: 'rms1qqrmnqwysw6y7n0lhyju39p68fwwdv3a4m3khh0paczh2wft2wy853pmqmz',
+    keyIndex: 0,
+    internal: false,
+    used: false
+  }
+]
+
+<Account Name>'s Total Balance:
 {
   baseCoin: { total: '1000000000', available: '1000000000' },
   requiredStorageDeposit: '42600',

--- a/tutorials/single-page-tutorials/wallet-setup.md
+++ b/tutorials/single-page-tutorials/wallet-setup.md
@@ -85,11 +85,17 @@ module.exports = { networkConfig };
 
 Create a new `.env` file and add the content below:
 
+:::note
+
+In the .env file you don't need to end lines with comas or semicolons and you also don't need to enclose variables with quotation marks. Just make sure to use a new line for every variable.
+
+:::
+
 ```javascript
-ACCOUNT_NAME = '<Enter_your_name_here>';
-SH_PASSWORD = '<Enter_your_password_here>';
+ACCOUNT_NAME = Enter_your_name_here;
+SH_PASSWORD = Enter_your_password_here;
 MNEMONIC =
-  '<You_will_create_your_own_mnemonic_seed_phrase_in_the_next_step_and_paste_it_in_here>';
+  You_will_create_your_own_mnemonic_seed_phrase_in_the_next_step_and_paste_it_in_here;
 ```
 
 Enter your desired account name as well as a secure Stronghold password. You will create your new mnemonic seed phrase in the next step and paste it here afterward.
@@ -413,7 +419,7 @@ const faucetApi = networkConfig.faucetApi;
 const consoleColor = '\x1b[36m%s\x1b[0m';
 
 // Address to receive faucet tokens
-const receivingAddress = '<paste_your_previously_generated_address_here>';
+const receivingAddress = '<paste_your_address_here>';
 
 async function run() {
   const request = await requestFunds(faucetApi, receivingAddress);


### PR DESCRIPTION
# Description of change

I removed the creation of a new address from this tutorial. Follow-up tutorials (e.g. nested NFTs), which use this tutorial as a prerequisite, require funds of the very first address of the provided Stronghold account. Since creating a new Stronghold account automatically creates a first address, this address should be used to receive funds. I also fixed the wrongly presented syntax in the .env file.

## Type of change

Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas

