### PR TITLE
Use root and defaults to correctly update lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,9 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     versioning-strategy: increase
-    directory: '/cli'
+    directory: '/'
     schedule:
       interval: 'monthly'
-    labels:
-      - 'dependencies'
-    open-pull-requests-limit: 100
-    pull-request-branch-name:
-      separator: '-'
     ignore:
       - dependency-name: 'fs-extra'
       - dependency-name: '*'


### PR DESCRIPTION
# Description of change

Dependabot needs the location of the lock file, so using the workspace subdirectory of the CLI doesn't work, it needs to be root. Also some settings were verbose versions of the default, so I removed those. And I changed the branch naming to use default '/'.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
