### PR TITLE
Remove cache from tag jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -101,7 +101,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
       - name: Allow modern Yarn
         run: |
           corepack enable
@@ -129,7 +128,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
       - name: Allow modern Yarn
         run: |
           corepack enable


### PR DESCRIPTION
# Description of change

The workflows complain there is no cache on disk, which is correct, since we actually don't install anything in these jobs. So I removed the cache.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
