### PR TITLE
Fix tutorial preview images

### DIFF
--- a/tutorials/docusaurus.config.js
+++ b/tutorials/docusaurus.config.js
@@ -16,7 +16,7 @@ module.exports = {
         title: 'Send IOTA Tokens with Javascript',
         description:
           'In this tutorial you will learn how to send IOTA Tokens in the Devnet.',
-        preview: 'send-iota-tokens-with-javascript.svg',
+        preview: '/send-iota-tokens-with-javascript.svg',
         route: 'tutorials/send-iota-tokens-with-javascript',
         tags: ['text', 'getting-started', 'client', 'js', 'mainnet'],
       },
@@ -26,7 +26,7 @@ module.exports = {
       {
         title: 'Run a Wasp Node',
         description: 'In this tutorial you will learn how to run a wasp node.',
-        preview: 'IOTA-Smart-Contract-Tutorials-A.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-A.jpg',
         route: 'smart-contracts/guide/chains_and_nodes/running-a-node',
         tags: ['text', 'video'],
       },
@@ -36,7 +36,7 @@ module.exports = {
       {
         title: 'Run a Wasp Chain',
         description: 'In this tutorial you will learn how to run a wasp chain.',
-        preview: 'IOTA-Smart-Contract-Tutorials-B.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-B.jpg',
         route: 'smart-contracts/guide/chains_and_nodes/setting-up-a-chain',
         tags: ['text', 'video'],
       },
@@ -47,7 +47,7 @@ module.exports = {
         title: 'Deploy a WASM Smart Contract',
         description:
           'In this tutorial you will learn how to deploy a wasm smart contract.',
-        preview: 'IOTA-Smart-Contract-Tutorials-C.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-C.jpg',
         route:
           'smart-contracts/guide/chains_and_nodes/setting-up-a-chain#deploying-a-wasm-contract',
         tags: ['text', 'video'],
@@ -58,7 +58,7 @@ module.exports = {
       {
         title: 'Run a EVM Chain',
         description: 'In this tutorial you will learn how to run an EVM node.',
-        preview: 'IOTA-Smart-Contract-Tutorials-D.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-D.jpg',
         route: 'smart-contracts/guide/evm/create-chain',
         tags: ['text', 'video'],
       },
@@ -69,7 +69,7 @@ module.exports = {
         title: 'Deploy Solidity Smart Contract using Remix + Metamask',
         description:
           'In this tutorial you will learn how to deploy a solidity smart contract on EVM using remix and metamask.',
-        preview: 'IOTA-Smart-Contract-Tutorials-E.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-E.jpg',
         route: 'smart-contracts/guide/evm/tooling#remix',
         tags: ['text', 'video'],
       },
@@ -80,7 +80,7 @@ module.exports = {
         title: 'Deploy Solidity Smart Contract using Hardhat',
         description:
           'In this tutorial you will learn how to deploy a solidity smart contract on EVM using hardhat.',
-        preview: 'IOTA-Smart-Contract-Tutorials-F.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-F.jpg',
         route: 'smart-contracts/guide/evm/tooling#hardhat',
         tags: ['text', 'video'],
       },
@@ -91,7 +91,7 @@ module.exports = {
         title: 'Generate WASM Smart Contract using Schema Tool',
         description:
           'In this tutorial you will learn how to use schema tool to generate smart contract template code on rust and golang',
-        preview: 'IOTA-Smart-Contract-Tutorials-G.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-G.jpg',
         route: 'smart-contracts/guide/wasm_vm/usage',
         tags: ['text', 'video'],
       },
@@ -102,7 +102,7 @@ module.exports = {
         title: 'Generate WASM Smart Contract using Schema Tool in Typescript',
         description:
           'In this tutorial you will learn how to use schema tool to generate smart contract template code on typescript',
-        preview: 'IOTA-Smart-Contract-Tutorials-G.jpg',
+        preview: '/IOTA-Smart-Contract-Tutorials-G.jpg',
         route: 'https://www.youtube.com/watch?v=P5HMgmY3DMM',
         tags: ['video'],
       },
@@ -113,7 +113,7 @@ module.exports = {
         title: 'Send Shimmer Tokens with wallet.rs',
         description:
           'In this tutorial you will learn how to send Shimmer Tokens with wallet.rs.',
-        preview: 'send-shimmer-tokens-with-wallet-lib.png',
+        preview: '/send-shimmer-tokens-with-wallet-lib.png',
         route: 'tutorials/send-shimmer-tokens-with-wallet-lib',
         tags: ['text', 'wallet', 'getting-started', 'rust', 'shimmer'],
       },
@@ -124,7 +124,7 @@ module.exports = {
         title: 'Interact with IOTA Node Extension (INX)',
         description:
           'In this tutorial you will learn how to interact with the IOTA Node Extension (INX) interface based on gRPC.',
-        preview: 'hornet-inx-interaction.png',
+        preview: '/hornet-inx-interaction.png',
         route: 'tutorials/hornet-inx-interaction',
         tags: ['text', 'getting-started', 'shimmer', 'js'],
       },
@@ -135,7 +135,7 @@ module.exports = {
         title: 'Tokenless Data Notarization',
         description:
           'Proove that a block was part of the past Tangle, even if this part of the Tangle was already pruned from network nodes.',
-        preview: 'proof-inclusion-of-a-block.png',
+        preview: '/proof-inclusion-of-a-block.png',
         route: 'tutorials/proof-inclusion-of-a-block',
         tags: ['text', 'getting-started', 'js', 'client', 'shimmer'],
       },
@@ -146,7 +146,7 @@ module.exports = {
         title: 'Setup testnet address and receive funds from faucet',
         description:
           'In this tutorial you will learn how to create a seed and address with wallet.rs and receive testnet tokens from the faucet.',
-        preview: 'wallet-setup.png',
+        preview: '/wallet-setup.png',
         route: 'tutorials/wallet-setup',
         tags: ['text', 'getting-started', 'node_js', 'wallet', 'shimmer'],
       },
@@ -157,7 +157,7 @@ module.exports = {
         title: 'How to Setup iota.js for Development',
         description:
           'In this tutorial you will learn how to create a new project, generate a new address and receive x funds from the faucet.',
-        preview: 'setup_iota-js_for_development.png',
+        preview: '/setup_iota-js_for_development.png',
         route: 'tutorials/setup_iota-js_for_development',
         tags: ['text', 'getting-started', 'client', 'shimmer', 'js'],
       },
@@ -168,7 +168,7 @@ module.exports = {
         title: 'Create a NFT with wallet.rs and IPFS',
         description:
           'In this tutorial you will learn how to create a NFT on the Shimmer network with wallet.rs and IPFS.',
-        preview: 'create-nft-with-wallet-lib.png',
+        preview: '/create-nft-with-wallet-lib.png',
         route: 'tutorials/create-nft-with-wallet-lib',
         tags: [
           'text',
@@ -186,7 +186,7 @@ module.exports = {
         title: 'Send Shimmer Tokens with Javascript',
         description:
           'In this tutorial you will learn how to send Shimmer Tokens in the testnet.',
-        preview: 'send-shimmer-tokens-with-javascript.png',
+        preview: '/send-shimmer-tokens-with-javascript.png',
         route: 'tutorials/send-shimmer-tokens-with-javascript',
         tags: [
           'text',
@@ -202,10 +202,11 @@ module.exports = {
     [
       '@iota-wiki/plugin-tutorial',
       {
-        title: 'Connect to Shimmer EVM Testnet and deploy a Solidity Smart Contract',
+        title:
+          'Connect to Shimmer EVM Testnet and deploy a Solidity Smart Contract',
         description:
           'In this tutorial, we will connect to Shimmer EVM Testnet, connect Metamask to it, get funded and deploy a smart contract in Solidity.',
-        preview: 'connect-shimmerevm-testnet-and-deploy.png',
+        preview: '/connect-shimmerevm-testnet-and-deploy.png',
         route: 'tutorials/shimmerevm-setup',
         tags: [
           'text',
@@ -213,7 +214,7 @@ module.exports = {
           'solidity',
           'getting-started',
           'wasp',
-          'iscp'
+          'iscp',
         ],
       },
     ],


### PR DESCRIPTION
# Description of change

As observed by @JSto91, the preview images of the tutorials were broken. We have to use absolute paths to correctly resolve the assets in the static folder.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
