### PR TITLE
Check if package versions changed compared to `main` in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,7 @@ jobs:
           diff-search: true
           file-name: ./package.json
       - name: Check @iota-wiki/core changed compared to main branch
+        if: github.ref != 'refs/heads/main'
         id: core-to-main
         uses: EndBug/version-check@v2
         with:
@@ -35,6 +36,7 @@ jobs:
           diff-search: true
           file-name: ./cli/package.json
       - name: Check @iota-wiki/cli changed compared to main branch
+        if: github.ref != 'refs/heads/main'
         id: cli-to-main
         uses: EndBug/version-check@v2
         with:
@@ -43,9 +45,9 @@ jobs:
           file-url: https://raw.githubusercontent.com/iota-wiki/iota-wiki/main/cli/package.json
           static-checking: localIsNew
     outputs:
-      core-changed: ${{ steps.core-to-current.outputs.changed && steps.core-to-main.outputs.changed}}
+      core-changed: ${{ steps.core-to-current.outputs.changed && (github.ref == 'refs/heads/main' || steps.core-to-main.outputs.changed) }}
       core-version: ${{ steps.core-to-current.outputs.version }}
-      cli-changed: ${{ steps.cli-to-current.outputs.changed && steps.cli-to-main.outputs.changed}}
+      cli-changed: ${{ steps.cli-to-current.outputs.changed && (github.ref == 'refs/heads/main' || steps.cli-to-main.outputs.changed) }}
       cli-version: ${{ steps.cli-to-current.outputs.version }}
   publish-core:
     # If not on main and version changed, publish with experimental tag

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,5 @@
+# TODO: Remove assumption version is increased to unreleased version.
+
 name: Publish
 on: push
 jobs:
@@ -10,25 +12,41 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-      - name: core
-        id: core
+      # Check if core changed
+      - name: Check @iota-wiki/core changed in current branch
+        id: core-to-current
         uses: EndBug/version-check@v2
         with:
           diff-search: true
-          assume-same-version: new
           file-name: ./package.json
-      - name: cli
-        id: cli
+      - name: Check @iota-wiki/core changed compared to main branch
+        id: core-to-main
         uses: EndBug/version-check@v2
         with:
           diff-search: true
-          assume-same-version: new
+          file-name: ./package.json
+          file-url: https://raw.githubusercontent.com/iota-wiki/iota-wiki/main/package.json
+          static-checking: localIsNew
+      # Check if cli changed
+      - name: Check @iota-wiki/cli changed in current branch
+        id: cli-to-current
+        uses: EndBug/version-check@v2
+        with:
+          diff-search: true
           file-name: ./cli/package.json
+      - name: Check @iota-wiki/cli changed compared to main branch
+        id: cli-to-main
+        uses: EndBug/version-check@v2
+        with:
+          diff-search: true
+          file-name: ./cli/package.json
+          file-url: https://raw.githubusercontent.com/iota-wiki/iota-wiki/main/cli/package.json
+          static-checking: localIsNew
     outputs:
-      core-changed: ${{ steps.core.outputs.changed }}
-      core-version: ${{ steps.core.outputs.version }}
-      cli-changed: ${{ steps.cli.outputs.changed }}
-      cli-version: ${{ steps.cli.outputs.version }}
+      core-changed: ${{ steps.core-to-current.outputs.changed && steps.core-to-main.outputs.changed}}
+      core-version: ${{ steps.core-to-current.outputs.version }}
+      cli-changed: ${{ steps.cli-to-current.outputs.changed && steps.cli-to-main.outputs.changed}}
+      cli-version: ${{ steps.cli-to-current.outputs.version }}
   publish-core:
     # If not on main and version changed, publish with experimental tag
     runs-on: ubuntu-latest

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "description": "A command line utility to manage Wiki content and preview content locally.",
   "author": "IOTA community",
   "license": "MIT",
-  "version": "2.0.3-alpha.0",
+  "version": "2.0.2",
   "homepage": "https://github.com/iota-wiki/iota-wiki/cli",
   "bugs": "https://github.com/iota-wiki/iota-wiki/issues",
   "repository": "iota-wiki/iota-wiki",

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "description": "A command line utility to manage Wiki content and preview content locally.",
   "author": "IOTA community",
   "license": "MIT",
-  "version": "2.0.2",
+  "version": "2.0.3-alpha.0",
   "homepage": "https://github.com/iota-wiki/iota-wiki/cli",
   "bugs": "https://github.com/iota-wiki/iota-wiki/issues",
   "repository": "iota-wiki/iota-wiki",


### PR DESCRIPTION
# Description of change

Currently, the publish workflow tries to publish when the version changes in pushed commits. This is especially annoying when you try to resolve merge conflicts by merging `main` into the current branch, possibly resulting in pushed commits that change the version to an already published one. This PR temporarily fixes that specific case by also comparing the version in the current branch against the version in the main branch.

(Manually canceled) workflow run where CLI version changed, correctly tries to publish CLI package: https://github.com/iota-wiki/iota-wiki/actions/runs/3699116229
Workflow run where CLI version was reverted to the same version as `main`, correctly skips publishing of CLI package: https://github.com/iota-wiki/iota-wiki/actions/runs/3699131510

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
