### PR TITLE
Change Wasp documentation branch on Shimmer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,10 +18,6 @@
 	path = iota/external/wallet.rs/production
 	url = https://github.com/iotaledger/wallet.rs
   	branch = production
-[submodule "iota/external/wasp/develop"]
-	path = iota/external/wasp/develop
-	url = https://github.com/iotaledger/wasp
-	branch = develop
 [submodule "iota/external/zebra-iota-edge-sdk/production"]
 	path = iota/external/zebra-iota-edge-sdk/production
 	url = https://github.com/ZebraDevs/Zebra-Iota-Edge-SDK
@@ -97,7 +93,7 @@
 [submodule "shimmer/external/wasp"]
 	path = shimmer/external/wasp
 	url = https://github.com/iotaledger/wasp
-	branch = master
+	branch = develop
 [submodule "shimmer/external/inx-poi"]
 	path = shimmer/external/inx-poi
 	url = https://github.com/iotaledger/inx-poi


### PR DESCRIPTION
# Description of change

As SC aren't stable yet anyway, we should publish the develop docs on Shimmer too and not only on Next

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
