### PR TITLE
Remove ideal image

### DIFF
--- a/common/docusaurus.config.js
+++ b/common/docusaurus.config.js
@@ -40,7 +40,6 @@ module.exports = {
   },
   plugins: [
     'plugin-image-zoom',
-    '@docusaurus/plugin-ideal-image',
     [
       '@docusaurus/plugin-content-pages',
       {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@algolia/client-search": "^4.14.1",
     "@docusaurus/core": "2.2.0",
     "@docusaurus/plugin-client-redirects": "2.2.0",
-    "@docusaurus/plugin-ideal-image": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@iota-wiki/plugin-tutorial": "^1.0.6",
     "@mdx-js/react": "^1.6.21",

--- a/src/common/components/TutorialCard/index.tsx
+++ b/src/common/components/TutorialCard/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { memo, useState } from 'react';
-import Image from '@theme/IdealImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import clsx from 'clsx';
 
@@ -63,9 +62,9 @@ const TutorialCard = memo(({ tutorial }: { tutorial: Tutorial }) => {
         className='card shadow--md tutorial-card'
       >
         <div className='card__image tutorial-card__image-container'>
-          <Image
+          <img
             className='tutorial-card__image'
-            img={tutorial.preview}
+            src={tutorial.preview}
             alt={tutorial.title}
           />
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,7 +1985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-ideal-image@npm:2.2.0, @docusaurus/plugin-ideal-image@npm:^2.0.1":
+"@docusaurus/plugin-ideal-image@npm:^2.0.1":
   version: 2.2.0
   resolution: "@docusaurus/plugin-ideal-image@npm:2.2.0"
   dependencies:
@@ -2521,7 +2521,6 @@ __metadata:
     "@docusaurus/module-type-aliases": 2.2.0
     "@docusaurus/plugin-client-redirects": 2.2.0
     "@docusaurus/plugin-google-gtag": 2.2.0
-    "@docusaurus/plugin-ideal-image": 2.2.0
     "@docusaurus/preset-classic": 2.2.0
     "@iota-wiki/plugin-tutorial": ^1.0.6
     "@mdx-js/react": ^1.6.21


### PR DESCRIPTION
# Description of change

@JSto91 was trying to add images, as [recommended by Docusaurus](https://docusaurus.io/docs/static-assets#in-jsx), but it is failing because of the `@docusaurus/plugin-ideal-image` plugin. It interferes with the recommended approach because it takes *all* raster image imports throughout the Wiki and converts them into objects instead of the expected canonical URLs, forcing the use of their `@theme/IdealImage` component which is unexpected and far from ideal. We are only using it in the tutorial section, it prevents using the recommended approach, and it prevents using the recommended light/dark image theme mechanism we want to use. So I removed it.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
