### PR TITLE
Fix tutorial banner alignment

### DIFF
--- a/src/common/components/TutorialCard/styles.css
+++ b/src/common/components/TutorialCard/styles.css
@@ -18,7 +18,7 @@
 
 .tutorial-card__image-container {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   overflow: hidden;
   height: 150px;


### PR DESCRIPTION
# Description of change

Now the banners are centered in the cards.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
