### PR TITLE
Fix relative links in developer welcome page

### DIFF
--- a/iota/develop/welcome.md
+++ b/iota/develop/welcome.md
@@ -12,16 +12,16 @@ Welcome to the Developer Section. Here you will find all information to start de
   - [Streams](/streams/welcome)
   - [Stronghold](/stronghold.rs/welcome)
 - Node Software
-  - [Introduction](nodes/node-software)
+  - [Introduction](nodes/node-software.md)
   - [Hornet](/hornet/welcome)
   - [Bee](/bee/welcome)
   - [Chronicle](/chronicle/welcome)
 - About Nodes
-  - [Introduction](nodes/about-nodes)
-  - [Become a Node Operator](nodes/become-a-node-operator)
-  - [API Reference](nodes/api_reference)
+  - [Introduction](nodes/about-nodes.md)
+  - [Become a Node Operator](nodes/become-a-node-operator.md)
+  - [API Reference](nodes/api_reference.md)
   - Explanations
-    - [Nodes 101](nodes/explanations/nodes_101)
-    - [Security 101](nodes/explanations/security_101)
-- [Network Token Migration](network-token-migration)
+    - [Nodes 101](nodes/explanations/nodes_101.md)
+    - [Security 101](nodes/explanations/security_101.md)
+- [Network Token Migration](network-token-migration.md)
 - [Tutorials](/tutorials)

--- a/next/develop/welcome.md
+++ b/next/develop/welcome.md
@@ -17,7 +17,7 @@ Welcome to the Developer Section. Here you will find all information to start de
   - [Identity](/identity.rs/introduction)
   - [Stronghold](/stronghold.rs/welcome)
 - Node Software
-  - [Introduction](nodes/node-software)
+  - [Introduction](nodes/node-software.md)
   - [Hornet](/hornet/welcome)
   - INX Plugins
     - [Indexer](/inx-indexer/welcome)
@@ -31,12 +31,12 @@ Welcome to the Developer Section. Here you will find all information to start de
     - [Wasp](/smart-contracts/guide/chains_and_nodes/running-a-node)
     - [Chronicle](/chronicle/welcome)
 - About Nodes
-  - [Introduction](nodes/about-nodes)
-  - [Become a Node Operator](nodes/become-a-node-operator)
-  - [API Reference](nodes/api_reference)
+  - [Introduction](nodes/about-nodes.md)
+  - [Become a Node Operator](nodes/become-a-node-operator.md)
+  - [API Reference](nodes/api_reference.md)
   - Explanations
-    - [Nodes 101](nodes/explanations/nodes_101)
-    - [Security 101](nodes/explanations/security_101)
+    - [Nodes 101](nodes/explanations/nodes_101.md)
+    - [Security 101](nodes/explanations/security_101.md)
 - [Tools](/develop/tools)
   - [CLI Wallet](/cli-wallet/welcome)
   - [WASP CLI](/smart-contracts/guide/chains_and_nodes/wasp-cli)

--- a/shimmer/develop/welcome.md
+++ b/shimmer/develop/welcome.md
@@ -17,7 +17,7 @@ Welcome to the Developer Section. Here you will find all information to start de
   - [Identity](/identity.rs/introduction)
   - [Stronghold](/stronghold.rs/welcome)
 - Node Software
-  - [Introduction](nodes/node-software)
+  - [Introduction](nodes/node-software.md)
   - [Hornet](/hornet/welcome)
   - INX Plugins
     - [Indexer](/inx-indexer/welcome)
@@ -31,12 +31,12 @@ Welcome to the Developer Section. Here you will find all information to start de
     - [Wasp](/smart-contracts/guide/chains_and_nodes/running-a-node)
     - [Chronicle](/chronicle/welcome)
 - About Nodes
-  - [Introduction](nodes/about-nodes)
-  - [Become a Node Operator](nodes/become-a-node-operator)
-  - [API Reference](nodes/api_reference)
+  - [Introduction](nodes/about-nodes.md)
+  - [Become a Node Operator](nodes/become-a-node-operator.md)
+  - [API Reference](nodes/api_reference.md)
   - Explanations
-    - [Nodes 101](nodes/explanations/nodes_101)
-    - [Security 101](nodes/explanations/security_101)
+    - [Nodes 101](nodes/explanations/nodes_101.md)
+    - [Security 101](nodes/explanations/security_101.md)
 - [Tools](/develop/tools)
   - [CLI Wallet](/cli-wallet/welcome)
   - [WASP CLI](/smart-contracts/guide/chains_and_nodes/wasp-cli)


### PR DESCRIPTION
# Description of change

As we switched to `trailingSlash: true` with the migration to Vercel we broke relative links like mentioned in the [docusaurus docs](https://docusaurus.io/docs/markdown-features/links):
`Relative URL links are very likely to break if you update the trailingSlash config`.

To fix it we should use relative file paths with extension which comes with the in the link above mentioned benefits.

Now there is only one question up for discussion:

- [ ] Should we also port "external" links to this format? For example  `hornet/welcome.md`. This would be consistent, but I guess not it breaks more easily if they would change the welcome file to `.mdx`. But I think in favour of being consistent this makes sense. Wdyt?

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
