### PR TITLE
Fix EditUrl regex

### DIFF
--- a/src/theme/EditThisPage/index.tsx
+++ b/src/theme/EditThisPage/index.tsx
@@ -11,28 +11,22 @@ import type { WrapperProps } from '@docusaurus/types';
 
 type Props = WrapperProps<typeof EditThisPageType>;
 
+const externalDocsRegex = new RegExp(
+    'shimmer/external/[^/]*/[^/]*/[^/]*/|iota/external/[^/]*/[^/]*/[^/]*/',
+    'i',
+);
+
 /**
-This function will remove 
-"content/build/anyOtherString/anyOtherString/anyOtherString"
-or
-"external/anyOtherString"
+This function will remove the links in the regex above
 **/
 function reformatExternalProjectURL(editUrl) {
-  const externalDocsRegex = new RegExp(
-    'shimmer/external/[^/]*/[^/]*/|iota/external/[^/]*/[^/]*/[^/]*/',
-    'i',
-  );
   return editUrl.replace(externalDocsRegex, '');
 }
 
 /**
-This function will check if docs is in "content/build/" or "external/"
+This function will check if docs is one of the links from the regex above"
 **/
 function isExternalProjectURL(editUrl) {
-  const externalDocsRegex = new RegExp(
-    'shimmer/external/[^/]*/[^/]*/|iota/external/[^/]*/[^/]*/[^/]*/',
-    'i',
-  );
   return externalDocsRegex.test(editUrl);
 }
 


### PR DESCRIPTION
# Description of change

Fixed the regex in the EditUrl component. Because right not it doesn't seem to work for the [Shimmer version of stronghold](https://wiki.iota.org/stronghold.rs/welcome/).

## Links to any relevant issues

This is related to #860 because I couldn't fix the links through the edit button 😢 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
