### PR TITLE
feat: add cookiebot

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --force --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --force --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const production = {
   },
   plugins: [
     path.resolve(__dirname, 'plugins', 'cookiebot'),
-    // 'docusaurus-plugin-matomo',
+    path.resolve(__dirname, 'plugins', 'matomo'),
     [
       '@docusaurus/plugin-google-gtag',
       {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,8 @@ const production = {
     },
   },
   plugins: [
-    'docusaurus-plugin-matomo',
+    path.resolve(__dirname, 'plugins', 'cookiebot'),
+    // 'docusaurus-plugin-matomo',
     [
       '@docusaurus/plugin-google-gtag',
       {

--- a/iota/docusaurus.config.js
+++ b/iota/docusaurus.config.js
@@ -154,7 +154,7 @@ module.exports = {
         src: 'img/footer_logo.svg',
         href: 'https://www.iota.org',
       },
-      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus.`,
+      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus. <a href="/cookie-policy"> Cookie Policy. </a>`,
     },
     socials: [
       {

--- a/next/docusaurus.config.js
+++ b/next/docusaurus.config.js
@@ -140,7 +140,7 @@ module.exports = {
         src: 'img/footer_logo.svg',
         href: 'https://www.shimmer.network',
       },
-      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus.`,
+      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus. <a href="/cookie-policy"> Cookie Policy. </a>`,
     },
     socials: [
       {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@svgr/webpack": "^5.5.0",
     "callsite": "^1.0.0",
     "clsx": "^1.2.1",
-    "docusaurus-plugin-matomo": "^0.0.5",
     "docusaurus-plugin-openapi-docs": "^1.4.7",
     "docusaurus-theme-openapi-docs": "^1.4.7",
     "file-loader": "^6.2.0",

--- a/plugins/cookiebot/index.js
+++ b/plugins/cookiebot/index.js
@@ -1,0 +1,31 @@
+module.exports = function () {
+  return {
+    name: 'docusaurus-cookie-plugin',
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              id: 'Cookiebot',
+              src: 'https://consent.cookiebot.com/uc.js',
+              'data-cbid': '8f051d60-4ecb-41a0-abb9-4874fd999e4f',
+              'data-blockingmode': 'auto',
+              type: 'text/javascript',
+            },
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              src: '/js/matomo-cookiebot.js',
+              type: 'text/javascript',
+              async: false,
+            },
+          },
+        ],
+        preBodyTags: [],
+        postBodyTags: [],
+      };
+    },
+  };
+};

--- a/plugins/cookiebot/index.js
+++ b/plugins/cookiebot/index.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   return {
-    name: 'docusaurus-cookie-plugin',
+    name: 'docusaurus-cookiebot-plugin',
     injectHtmlTags() {
       return {
         headTags: [

--- a/plugins/matomo/index.js
+++ b/plugins/matomo/index.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   return {
-    name: 'docusaurus-cookie-plugin',
+    name: 'docusaurus-matomo-plugin',
     injectHtmlTags() {
       return {
         headTags: [

--- a/plugins/matomo/index.js
+++ b/plugins/matomo/index.js
@@ -7,11 +7,17 @@ module.exports = function () {
           {
             tagName: 'script',
             attributes: {
-              id: 'Cookiebot',
-              src: 'https://consent.cookiebot.com/uc.js',
-              'data-cbid': '8f051d60-4ecb-41a0-abb9-4874fd999e4f',
-              'data-blockingmode': 'auto',
+              src: '/js/matomo-cookiebot.js',
               type: 'text/javascript',
+              async: false,
+            },
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              src: '/js/matomo.js',
+              type: 'text/javascript',
+              async: false,
             },
           },
         ],

--- a/shimmer/docusaurus.config.js
+++ b/shimmer/docusaurus.config.js
@@ -134,7 +134,7 @@ module.exports = {
         src: 'img/footer_logo.svg',
         href: 'https://www.shimmer.network',
       },
-      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus.`,
+      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus. <a href="/cookie-policy"> Cookie Policy. </a>`,
     },
     socials: [
       {

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -1,9 +1,10 @@
 import Layout from '@theme/Layout';
-import React,{ useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 export default function CookiePolicy() {
   useEffect(() => {
-    const scriptPromise = new Promise((resolve, reject) => {
+
+    const appendCookiebotCdReport = new Promise((resolve, reject) => {
       const script = document.createElement('script');
       document.body.appendChild(script);
       script.onload = resolve;
@@ -13,21 +14,37 @@ export default function CookiePolicy() {
         'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cdreport.js?referer=iota-wiki-fawn.vercel.app';
     });
 
-    const script = document.createElement('script');
-    script.id = 'CookieDeclaration';
-    script.src =
-      'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cd.js';
-    script.type = 'text/javascript';
-    script.async = true;
-    const cookieDeclarationWrapper = document.getElementById(
-      'cookie-declaration-wrapper',
-    );
-    cookieDeclarationWrapper.appendChild(script);
-
-    scriptPromise.then(() => {
-      console.log('loaded stuff');
+    const appendCookiebotDeclaration = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.id = 'CookieDeclaration';
+      script.src =
+        'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cd.js';
+      script.type = 'text/javascript';
+      script.async = true;
+      const cookieDeclarationWrapper = document.getElementById('cookie-declaration-wrapper');
+      document.getElementsByClassName('CookieDeclaration')
+      cookieDeclarationWrapper.appendChild(script);
+      script.onload = resolve;
+      script.onerror = reject;
     });
+
+    appendCookiebotCdReport.then(() => {
+      appendCookiebotDeclaration.then(() => {
+        const cookieDeclarations = document.getElementsByClassName('CookieDeclaration')
+        // Remove all duplicates
+        if (cookieDeclarations?.length > 1) {
+          for (let i = 1; i < cookieDeclarations.length; i++) {
+            cookieDeclarations[i].remove();
+          }
+        }
+      }).catch((error) => {
+        console.error(error)
+      });
+    }).catch((error) => {
+      console.error(error)
+    })
   }, []);
+
   return (
     <>
       <Layout>

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -1,0 +1,47 @@
+import Layout from '@theme/Layout';
+import React,{ useEffect } from 'react';
+
+export default function CookiePolicy() {
+  useEffect(() => {
+    const scriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      document.body.appendChild(script);
+      script.onload = resolve;
+      script.onerror = reject;
+      script.async = true;
+      script.src =
+        'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cdreport.js?referer=iota-wiki-fawn.vercel.app';
+    });
+
+    const script = document.createElement('script');
+    script.id = 'CookieDeclaration';
+    script.src =
+      'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cd.js';
+    script.type = 'text/javascript';
+    script.async = true;
+    const cookieDeclarationWrapper = document.getElementById(
+      'cookie-declaration-wrapper',
+    );
+    cookieDeclarationWrapper.appendChild(script);
+
+    scriptPromise.then(() => {
+      console.log('loaded stuff');
+    });
+  }, []);
+  return (
+    <>
+      <Layout>
+        <div className='hero'>
+          <div className='container'>
+            <div className='text--center margin-bottom--lg'>
+              <h1 className='hero__title margin--none'>Cookie Policy</h1>
+            </div>
+          </div>
+        </div>
+        <div className='container'>
+          <div id='cookie-declaration-wrapper'></div>
+        </div>
+      </Layout>
+    </>
+  );
+}

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -2,6 +2,14 @@ import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 
 export default function CookiePolicy() {
+
+
+  // Why is this needed?
+  // Injecting CookieBot as a global script in the HTML file 
+  // would make it load when the page loads instead of when the component is mounted
+  // And this would make it error because it would not be able to find where to inject the declaration
+  // So, we are injecting it twice, and just to be sure, we delete any extra cookie declaration, 
+  // as we only want to show one
   useEffect(() => {
 
     const appendCookiebotCdReport = new Promise((resolve, reject) => {
@@ -28,21 +36,20 @@ export default function CookiePolicy() {
       script.onerror = reject;
     });
 
-    appendCookiebotCdReport.then(() => {
-      appendCookiebotDeclaration.then(() => {
-        const cookieDeclarations = document.getElementsByClassName('CookieDeclaration')
+    Promise.all([appendCookiebotCdReport, appendCookiebotDeclaration]).then(() => {
+      const cookieDeclarations = document.getElementsByClassName('CookieDeclaration')
+      const interval = setInterval(() => {
         // Remove all duplicates
         if (cookieDeclarations?.length > 1) {
           for (let i = 1; i < cookieDeclarations.length; i++) {
             cookieDeclarations[i].remove();
           }
+          clearInterval(interval)
         }
-      }).catch((error) => {
-        console.error(error)
-      });
-    }).catch((error) => {
-      console.error(error)
+      }, 100);
     })
+    .then(() => console.error("Cookiebot loaded"))
+    .catch((err) => console.error(err))
   }, []);
 
   return (

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -36,9 +36,11 @@ export default function CookiePolicy() {
       script.onerror = reject;
     });
 
+    let interval = null;
+
     Promise.all([appendCookiebotCdReport, appendCookiebotDeclaration]).then(() => {
       const cookieDeclarations = document.getElementsByClassName('CookieDeclaration')
-      const interval = setInterval(() => {
+      interval = setInterval(() => {
         // Remove all duplicates
         if (cookieDeclarations?.length > 1) {
           for (let i = 1; i < cookieDeclarations.length; i++) {
@@ -50,6 +52,10 @@ export default function CookiePolicy() {
     })
     .then(() => console.error("Cookiebot loaded"))
     .catch((err) => console.error(err))
+    
+    return () => {
+      clearInterval(interval)
+    }
   }, []);
 
   return (

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -2,16 +2,13 @@ import Layout from '@theme/Layout';
 import React, { useEffect } from 'react';
 
 export default function CookiePolicy() {
-
-
   // Why is this needed?
-  // Injecting CookieBot as a global script in the HTML file 
+  // Injecting CookieBot as a global script in the HTML file
   // would make it load when the page loads instead of when the component is mounted
   // And this would make it error because it would not be able to find where to inject the declaration
-  // So, we are injecting it twice, and just to be sure, we delete any extra cookie declaration, 
+  // So, we are injecting it twice, and just to be sure, we delete any extra cookie declaration,
   // as we only want to show one
   useEffect(() => {
-
     const appendCookiebotCdReport = new Promise((resolve, reject) => {
       const script = document.createElement('script');
       document.body.appendChild(script);
@@ -29,8 +26,10 @@ export default function CookiePolicy() {
         'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cd.js';
       script.type = 'text/javascript';
       script.async = true;
-      const cookieDeclarationWrapper = document.getElementById('cookie-declaration-wrapper');
-      document.getElementsByClassName('CookieDeclaration')
+      const cookieDeclarationWrapper = document.getElementById(
+        'cookie-declaration-wrapper',
+      );
+      document.getElementsByClassName('CookieDeclaration');
       cookieDeclarationWrapper.appendChild(script);
       script.onload = resolve;
       script.onerror = reject;
@@ -38,24 +37,26 @@ export default function CookiePolicy() {
 
     let interval = null;
 
-    Promise.all([appendCookiebotCdReport, appendCookiebotDeclaration]).then(() => {
-      const cookieDeclarations = document.getElementsByClassName('CookieDeclaration')
-      interval = setInterval(() => {
-        // Remove all duplicates
-        if (cookieDeclarations?.length > 1) {
-          for (let i = 1; i < cookieDeclarations.length; i++) {
-            cookieDeclarations[i].remove();
+    Promise.all([appendCookiebotCdReport, appendCookiebotDeclaration])
+      .then(() => {
+        const cookieDeclarations =
+          document.getElementsByClassName('CookieDeclaration');
+        interval = setInterval(() => {
+          // Remove all duplicates
+          if (cookieDeclarations?.length > 1) {
+            for (let i = 1; i < cookieDeclarations.length; i++) {
+              cookieDeclarations[i].remove();
+            }
+            clearInterval(interval);
           }
-          clearInterval(interval)
-        }
-      }, 100);
-    })
-    .then(() => console.error("Cookiebot loaded"))
-    .catch((err) => console.error(err))
-    
+        }, 100);
+      })
+      .then(() => console.error('Cookiebot loaded'))
+      .catch((err) => console.error(err));
+
     return () => {
-      clearInterval(interval)
-    }
+      clearInterval(interval);
+    };
   }, []);
 
   return (

--- a/src/common/pages/cookie-policy/index.tsx
+++ b/src/common/pages/cookie-policy/index.tsx
@@ -16,7 +16,7 @@ export default function CookiePolicy() {
       script.onerror = reject;
       script.async = true;
       script.src =
-        'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cdreport.js?referer=iota-wiki-fawn.vercel.app';
+        'https://consent.cookiebot.com/8f051d60-4ecb-41a0-abb9-4874fd999e4f/cdreport.js?referer=wiki.iota.org';
     });
 
     const appendCookiebotDeclaration = new Promise((resolve, reject) => {

--- a/static/js/matomo-cookiebot.js
+++ b/static/js/matomo-cookiebot.js
@@ -1,9 +1,5 @@
 var waitForTrackerCount = 0;
 
-// needed to avoid site crash
-// var _paq = window._paq = window._paq || [];
-//
-
 function matomoWaitForTracker() {
   if (typeof _paq === 'undefined' || typeof Cookiebot === 'undefined') {
     if (waitForTrackerCount < 40) {

--- a/static/js/matomo-cookiebot.js
+++ b/static/js/matomo-cookiebot.js
@@ -1,0 +1,33 @@
+var waitForTrackerCount = 0;
+
+// needed to avoid site crash
+// var _paq = window._paq = window._paq || [];
+//
+
+function matomoWaitForTracker() {
+  if (typeof _paq === 'undefined' || typeof Cookiebot === 'undefined') {
+    if (waitForTrackerCount < 40) {
+      setTimeout(matomoWaitForTracker, 250);
+      waitForTrackerCount++;
+      return;
+    }
+  } else {
+    _paq.push(['requireConsent']);
+    window.addEventListener('CookiebotOnAccept', function (e) {
+      consentSet();
+    });
+    window.addEventListener('CookiebotOnDecline', function (e) {
+      consentSet();
+    });
+  }
+}
+function consentSet() {
+  if (Cookiebot.consent.statistics) {
+    _paq.push(['setCookieConsentGiven']);
+    _paq.push(['setConsentGiven']);
+  } else {
+    _paq.push(['forgetCookieConsentGiven']);
+    _paq.push(['forgetConsentGiven']);
+  }
+}
+document.addEventListener('DOMContentLoaded', matomoWaitForTracker());

--- a/static/js/matomo-cookiebot.js
+++ b/static/js/matomo-cookiebot.js
@@ -9,10 +9,10 @@ function matomoWaitForTracker() {
     }
   } else {
     _paq.push(['requireConsent']);
-    window.addEventListener('CookiebotOnAccept', function (e) {
+    window.addEventListener('CookiebotOnAccept', function () {
       consentSet();
     });
-    window.addEventListener('CookiebotOnDecline', function (e) {
+    window.addEventListener('CookiebotOnDecline', function () {
       consentSet();
     });
   }

--- a/static/js/matomo.js
+++ b/static/js/matomo.js
@@ -1,0 +1,16 @@
+var _paq = (window._paq = window._paq || []);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['requireCookieConsent']);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+  var u = 'https://matomo.iota-community.org/';
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '13']);
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,7 +2535,6 @@ __metadata:
     "@typescript-eslint/parser": ^5.9.1
     callsite: ^1.0.0
     clsx: ^1.2.1
-    docusaurus-plugin-matomo: ^0.0.5
     docusaurus-plugin-openapi-docs: ^1.4.7
     docusaurus-theme-openapi-docs: ^1.4.7
     eslint: ^8.6.0
@@ -6377,15 +6376,6 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
-  languageName: node
-  linkType: hard
-
-"docusaurus-plugin-matomo@npm:^0.0.5":
-  version: 0.0.5
-  resolution: "docusaurus-plugin-matomo@npm:0.0.5"
-  peerDependencies:
-    "@docusaurus/core": ^2.0.0-alpha.56
-  checksum: 8719dc9aa0c6350dc83c56bbc35dcc52d0aeb112f5aaf77e65ce5cdec9e06776dd56a4008d3cb10cbb64d258f93dfb538b557f9fa333d70e7cf618fd47ac3e21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description of change

This PR aims to add CookieBot to the wiki, in order to automatically manage third party cookies.
Because we have to whitelist in cookiebot every single allowed deploy, I created a deploy that is already whitelisted https://iota-wiki-ruddy.vercel.app

Please note that Matomo has been updated to work with Cookiebot, so it would be great knowing if indeed the change works

## Links to any relevant issues

Closes https://github.com/boxfish-studio/iota-wiki/issues/4

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix
- Documentation Enhancement

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [ ] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
