### PR TITLE
Docs - 870 - Add Tips To Sidebar

### DIFF
--- a/iota/develop/sidebars.ts
+++ b/iota/develop/sidebars.ts
@@ -7,6 +7,11 @@ module.exports = {
       href: '/introduction/welcome',
     },
     {
+      type: 'link',
+      label: 'Tangle Improvement Proposals (TIPS)',
+      href: '/tips',
+    },
+    {
       type: 'category',
       label: 'Libraries',
       collapsed: true,

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -7,6 +7,11 @@ module.exports = {
       href: '/introduction/welcome',
     },
     {
+      type: 'link',
+      label: 'Tangle Improvement Proposals (TIPS)',
+      href: '/tips',
+    },
+    {
       type: 'category',
       label: 'Smart Contracts',
       collapsed: true,

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -7,6 +7,11 @@ module.exports = {
       href: '/introduction/welcome',
     },
     {
+      type: 'link',
+      label: 'Tangle Improvement Proposals (TIPS)',
+      href: '/tips',
+    },
+    {
       type: 'category',
       label: 'Smart Contracts',
       collapsed: true,


### PR DESCRIPTION
# Description of change

Added tips to Next, Shimmer and IOTA develop sidebar

## Links to any relevant issues

patch for #870

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work

