### PR TITLE
Add endpoints docs to wiki

### DIFF
--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -16,7 +16,7 @@ Since the Chrysalis update, the `testnet` is now called `devnet`. We recommend u
 
 ## Public Infrastructure
 
-IOTA currently provides a load-balanced public devnet endpoint:
+The IOTA Foundation currently provides the following public load-balanced devnet endpoints:
 
 - [https://api.lb-0.h.chrysalis-devnet.iota.cafe/](https://api.lb-0.h.chrysalis-devnet.iota.cafe/).
 - [https://api.lb-1.h.chrysalis-devnet.iota.cafe/](https://api.lb-1.h.chrysalis-devnet.iota.cafe/).

--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -15,7 +15,7 @@ Since the Chrysalis update, the `testnet` is now called `devnet`.  We recommend 
 
 ## Public Infrastructure
 
-IOTA currently provides a load-balanced public devNet endpoint:
+IOTA currently provides a load-balanced public devnet endpoint:
 
 - [https://api.lb-0.h.chrysalis-devnet.iota.cafe/](https://api.lb-0.h.chrysalis-devnet.iota.cafe/).
 - [https://api.lb-1.h.chrysalis-devnet.iota.cafe/](https://api.lb-1.h.chrysalis-devnet.iota.cafe/).

--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -2,16 +2,17 @@
 description: The IOTA foundation provides load-balanced public devnet endpoints, where MQTT and the HTTP REST API are enabled.
 image: /img/logo/Chrysalis_logo_dark.png
 keywords:
-- devnet
-- load-balanced
-- HTTP REST API
-- MQTT
-- reference
-- Endpoints
+  - devnet
+  - load-balanced
+  - HTTP REST API
+  - MQTT
+  - reference
+  - Endpoints
 ---
+
 # Devnet
 
-Since the Chrysalis update, the `testnet` is now called `devnet`.  We recommend using the `devnet` to develop and test your application.  
+Since the Chrysalis update, the `testnet` is now called `devnet`. We recommend using the `devnet` to develop and test your application.
 
 ## Public Infrastructure
 

--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -1,0 +1,43 @@
+---
+description: The IOTA foundation provides load-balanced public devnet endpoints, where MQTT and the HTTP REST API are enabled.
+image: /img/logo/Chrysalis_logo_dark.png
+keywords:
+- devnet
+- load-balanced
+- HTTP REST API
+- MQTT
+- reference
+- Endpoints
+---
+# Devnet
+
+Since the Chrysalis update, the `testnet` is now called `devnet`.  We recommend using the `devnet` to develop and test your application.  
+
+## Public Infrastructure
+
+IOTA currently provides a load-balanced public devNet endpoint:
+
+- [https://api.lb-0.h.chrysalis-devnet.iota.cafe/](https://api.lb-0.h.chrysalis-devnet.iota.cafe/).
+- [https://api.lb-1.h.chrysalis-devnet.iota.cafe/](https://api.lb-1.h.chrysalis-devnet.iota.cafe/).
+
+:::note
+
+We recommend using the load balancer for most scenarios.
+
+:::
+
+We also provide single node endpoints that expose native [MQTT](https://mqtt.org/):
+
+- [https://api.thin-hornet-0.h.chrysalis-devnet.iota.cafe](https://api.thin-hornet-0.h.chrysalis-devnet.iota.cafe)
+- [https://api.thin-hornet-1.h.chrysalis-devnet.iota.cafe](https://api.thin-hornet-1.h.chrysalis-devnet.iota.cafe)
+- mqtt.lb-0.h.chrysalis-devnet.iota.cafe:1883
+- mqtt.lb-1.h.chrysalis-devnet.iota.cafe:1883
+
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/rest-api.yaml)) over TLS.
+
+## Developer Tools
+
+- [Explorer](https://explorer.iota.org/devnet).
+- [Online Faucet](https://faucet.chrysalis-devnet.iota.cafe).
+- [cli-wallet](https://github.com/iotaledger/cli-wallet).
+- [chrysalis-faucet Code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet).

--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -34,7 +34,7 @@ We also provide single node endpoints that expose native [MQTT](https://mqtt.org
 - mqtt.lb-0.h.chrysalis-devnet.iota.cafe:1883
 - mqtt.lb-1.h.chrysalis-devnet.iota.cafe:1883
 
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/rest-api.yaml)) over TLS.
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this [specification](nodes/rest-api/iota-rest-api.info.mdx)) over TLS.
 
 ## Developer Tools
 

--- a/iota/develop/endpoints/devnet.md
+++ b/iota/develop/endpoints/devnet.md
@@ -35,10 +35,3 @@ We also provide single node endpoints that expose native [MQTT](https://mqtt.org
 - mqtt.lb-1.h.chrysalis-devnet.iota.cafe:1883
 
 These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this [specification](nodes/rest-api/iota-rest-api.info.mdx)) over TLS.
-
-## Developer Tools
-
-- [Explorer](https://explorer.iota.org/devnet).
-- [Online Faucet](https://faucet.chrysalis-devnet.iota.cafe).
-- [cli-wallet](https://github.com/iotaledger/cli-wallet).
-- [chrysalis-faucet Code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet).

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -15,7 +15,7 @@ keywords:
 
 ## Public Infrastructure
 
-IOTA currently provides two load-balanced public mainnet endpoints:
+The IOTA Foundation currently provides the following public load-balanced mainnet endpoints:
 
 - https://chrysalis-nodes.iota.org.
 - https://chrysalis-nodes.iota.cafe.

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -1,0 +1,27 @@
+---
+description: The IOTA foundation provides load-balanced public mainnet endpoints where MQTT and the HTTP REST API are enabled. 
+image: /img/logo/Chrysalis_logo_dark.png
+keywords:
+- mainnet
+- MQTT
+- REST API
+- HTTP
+- Explorer
+- reference
+- Endpoints
+---
+# Mainnet
+
+## Public Infrastructure
+
+IOTA currently provides two load-balanced public mainnet endpoints:
+
+- chrysalis-nodes.iota.org.
+- chrysalis-nodes.iota.cafe.
+
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/0026-rest-api.yaml))
+over TLS.
+
+## Developer Tools
+
+- [Explorer](https://explorer.iota.org/mainnet).

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -22,7 +22,3 @@ The IOTA Foundation currently provides the following public load-balanced mainne
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to this [specification](nodes/rest-api/iota-rest-api.info.mdx))
 over TLS.
-
-## Developer Tools
-
-- [Explorer](https://explorer.iota.org/mainnet).

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -16,8 +16,8 @@ keywords:
 
 IOTA currently provides two load-balanced public mainnet endpoints:
 
-- chrysalis-nodes.iota.org.
-- chrysalis-nodes.iota.cafe.
+- https://chrysalis-nodes.iota.org.
+- https://chrysalis-nodes.iota.cafe.
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/0026-rest-api.yaml))
 over TLS.

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -1,15 +1,16 @@
 ---
-description: The IOTA foundation provides load-balanced public mainnet endpoints where MQTT and the HTTP REST API are enabled. 
+description: The IOTA foundation provides load-balanced public mainnet endpoints where MQTT and the HTTP REST API are enabled.
 image: /img/logo/Chrysalis_logo_dark.png
 keywords:
-- mainnet
-- MQTT
-- REST API
-- HTTP
-- Explorer
-- reference
-- Endpoints
+  - mainnet
+  - MQTT
+  - REST API
+  - HTTP
+  - Explorer
+  - reference
+  - Endpoints
 ---
+
 # Mainnet
 
 ## Public Infrastructure

--- a/iota/develop/endpoints/mainnet.md
+++ b/iota/develop/endpoints/mainnet.md
@@ -20,7 +20,7 @@ IOTA currently provides two load-balanced public mainnet endpoints:
 - https://chrysalis-nodes.iota.org.
 - https://chrysalis-nodes.iota.cafe.
 
-These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/0026-rest-api.yaml))
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to this [specification](nodes/rest-api/iota-rest-api.info.mdx))
 over TLS.
 
 ## Developer Tools

--- a/iota/develop/sidebars.ts
+++ b/iota/develop/sidebars.ts
@@ -106,6 +106,23 @@ module.exports = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Endpoints',
+      collapsed: true,
+      items: [            
+        {
+          type: 'doc',
+          id: 'endpoints/mainnet',
+          label: 'Mainnet'
+        },
+        {
+          type: 'doc',
+          id: 'endpoints/devnet',
+          label: 'Devnet'
+        },
+      ]
+    },
     'network-token-migration',
     {
       type: 'link',

--- a/iota/develop/sidebars.ts
+++ b/iota/develop/sidebars.ts
@@ -141,7 +141,7 @@ module.exports = {
           label: 'Devnet Faucet',
           type: 'link',
           href: 'https://faucet.chrysalis-devnet.iota.cafe',
-        }
+        },
       ],
     },
     'network-token-migration',

--- a/iota/develop/sidebars.ts
+++ b/iota/develop/sidebars.ts
@@ -110,18 +110,18 @@ module.exports = {
       type: 'category',
       label: 'Endpoints',
       collapsed: true,
-      items: [            
+      items: [
         {
           type: 'doc',
           id: 'endpoints/mainnet',
-          label: 'Mainnet'
+          label: 'Mainnet',
         },
         {
           type: 'doc',
           id: 'endpoints/devnet',
-          label: 'Devnet'
+          label: 'Devnet',
         },
-      ]
+      ],
     },
     'network-token-migration',
     {

--- a/iota/develop/sidebars.ts
+++ b/iota/develop/sidebars.ts
@@ -123,6 +123,27 @@ module.exports = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Tools',
+      link: {
+        type: 'generated-index',
+        title: 'Tools',
+        slug: '/tools',
+      },
+      items: [
+        {
+          label: 'Explorer',
+          type: 'link',
+          href: 'https://explorer.iota.org',
+        },
+        {
+          label: 'Devnet Faucet',
+          type: 'link',
+          href: 'https://faucet.chrysalis-devnet.iota.cafe',
+        }
+      ],
+    },
     'network-token-migration',
     {
       type: 'link',

--- a/next/develop/endpoints/shimmer.md
+++ b/next/develop/endpoints/shimmer.md
@@ -15,7 +15,7 @@ keywords:
 
 ## Public Infrastructure
 
-The IOTA Foundation currently provides these public load-balanced Shimmer endpoints:
+The IOTA Foundation currently provides the following public load-balanced Shimmer endpoints:
 
 Node API: https://api.shimmer.network  
 Example info endpoint: https://api.shimmer.network/api/core/v2/info  

--- a/next/develop/endpoints/shimmer.md
+++ b/next/develop/endpoints/shimmer.md
@@ -24,4 +24,4 @@ Health endpoint: https://api.shimmer.network/health
 MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
 Chronicle API: https://chronicle.shimmer.network
 
-These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](/tips/tips/TIP-0025), [TIP-26](/tips/tips/TIP-0026) and [TIP-28](/tips/tips/TIP-0028)) over TLS

--- a/next/develop/endpoints/shimmer.md
+++ b/next/develop/endpoints/shimmer.md
@@ -25,7 +25,3 @@ MQTT: wss://api.shimmer.network:443/api/mqtt/v1
 Chronicle API: https://chronicle.shimmer.network
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
-
-## Developer Tools
-
-- [Explorer](https://explorer.shimmer.network).

--- a/next/develop/endpoints/shimmer.md
+++ b/next/develop/endpoints/shimmer.md
@@ -1,0 +1,30 @@
+---
+description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled. 
+image: /img/logo/preview.png
+keywords:
+- shimmer
+- MQTT
+- REST API
+- HTTP
+- Explorer
+- reference
+- Endpoints
+---
+# Shimmer
+
+## Public Infrastructure
+
+The IOTA Foundation currently provides these public load-balanced Shimmer endpoints:
+
+Node API: https://api.shimmer.network  
+Example info endpoint: https://api.shimmer.network/api/core/v2/info  
+Available routes: https://api.shimmer.network/api/routes  
+Health endpoint: https://api.shimmer.network/health  
+MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
+Chronicle API: https://chronicle.shimmer.network  
+
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
+
+## Developer Tools
+
+- [Explorer](https://explorer.shimmer.network).

--- a/next/develop/endpoints/shimmer.md
+++ b/next/develop/endpoints/shimmer.md
@@ -1,15 +1,16 @@
 ---
-description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled. 
+description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
-- shimmer
-- MQTT
-- REST API
-- HTTP
-- Explorer
-- reference
-- Endpoints
+  - shimmer
+  - MQTT
+  - REST API
+  - HTTP
+  - Explorer
+  - reference
+  - Endpoints
 ---
+
 # Shimmer
 
 ## Public Infrastructure
@@ -21,7 +22,7 @@ Example info endpoint: https://api.shimmer.network/api/core/v2/info
 Available routes: https://api.shimmer.network/api/routes  
 Health endpoint: https://api.shimmer.network/health  
 MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
-Chronicle API: https://chronicle.shimmer.network  
+Chronicle API: https://chronicle.shimmer.network
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
 

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -27,4 +27,4 @@ The IOTA Foundation currently provides the following public load-balanced testne
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/rest-api/iota-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/core-rest-api/iota-core-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -1,0 +1,37 @@
+---
+description: The IOTA foundation provides load-balanced public Shimmer Beta endpoints, where MQTT and the HTTP REST API are enabled.
+image: /img/logo/preview.png
+keywords:
+- devnet
+- load-balanced
+- HTTP REST API
+- MQTT
+- reference
+- Endpoints
+---
+# Shimmer Beta
+
+Shimmer Beta is a pre-release of the Shimmer network that is currently under development.
+
+## Public Infrastructure
+
+We currently provide load-balanced public Shimmer Beta endpoints:
+
+ - Node API: https://api.testnet.shimmer.network
+   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
+   - Available routes: https://api.testnet.shimmer.network/api/routes
+   - Health endpoint: https://api.testnet.shimmer.network/health
+ - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+ - Chronicle API: https://chronicle.testnet.shimmer.network
+
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+
+## Developer Tools
+
+- [Explorer](https://explorer.shimmer.network)
+- [Online Faucet](https://faucet.testnet.shimmer.network)
+- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
+- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
+- [Cli-Wallet](https://github.com/iotaledger/cli-wallet/tree/develop)
+- [shimmer-faucet code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet/tree/hornet)
+- [shimmer-faucet backend](https://github.com/iotaledger/inx-faucet)

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -2,13 +2,14 @@
 description: The IOTA foundation provides load-balanced public testnet endpoints, where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
-- devnet
-- load-balanced
-- HTTP REST API
-- MQTT
-- reference
-- Endpoints
+  - devnet
+  - load-balanced
+  - HTTP REST API
+  - MQTT
+  - reference
+  - Endpoints
 ---
+
 # Testnet
 
 Testnet is a pre-release of the Shimmer network that is currently under development.
@@ -17,12 +18,12 @@ Testnet is a pre-release of the Shimmer network that is currently under developm
 
 We currently provide load-balanced public testnet endpoints:
 
- - Node API: https://api.testnet.shimmer.network
-   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
-   - Available routes: https://api.testnet.shimmer.network/api/routes
-   - Health endpoint: https://api.testnet.shimmer.network/health
- - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
- - Chronicle API: https://chronicle.testnet.shimmer.network
+- Node API: https://api.testnet.shimmer.network
+  - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
+  - Available routes: https://api.testnet.shimmer.network/api/routes
+  - Health endpoint: https://api.testnet.shimmer.network/health
+- MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+- Chronicle API: https://chronicle.testnet.shimmer.network
 
 These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
 

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -1,5 +1,5 @@
 ---
-description: The IOTA foundation provides load-balanced public Shimmer Beta endpoints, where MQTT and the HTTP REST API are enabled.
+description: The IOTA foundation provides load-balanced public testnet endpoints, where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
 - devnet
@@ -9,13 +9,13 @@ keywords:
 - reference
 - Endpoints
 ---
-# Shimmer Beta
+# Testnet
 
-Shimmer Beta is a pre-release of the Shimmer network that is currently under development.
+Testnet is a pre-release of the Shimmer network that is currently under development.
 
 ## Public Infrastructure
 
-We currently provide load-balanced public Shimmer Beta endpoints:
+We currently provide load-balanced public testnet endpoints:
 
  - Node API: https://api.testnet.shimmer.network
    - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
@@ -32,6 +32,3 @@ These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTT
 - [Online Faucet](https://faucet.testnet.shimmer.network)
 - Faucet Info API: https://faucet.testnet.shimmer.network/api/info
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
-- [Cli-Wallet](https://github.com/iotaledger/cli-wallet/tree/develop)
-- [shimmer-faucet code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet/tree/hornet)
-- [shimmer-faucet backend](https://github.com/iotaledger/inx-faucet)

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -27,4 +27,4 @@ The IOTA Foundation currently provides the following public load-balanced testne
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/rest-api/iota-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -10,9 +10,9 @@ keywords:
   - Endpoints
 ---
 
-# Testnet
+# Public Testnet
 
-Testnet is a pre-release of the Shimmer network that is currently under development.
+The testnet is the public infrastructure for developers. It runs on top of the beta releases of IOTA software and runs a [faucet](https://faucet.testnet.shimmer.network) to easily get tokens for testing.
 
 ## Public Infrastructure
 
@@ -23,13 +23,8 @@ The IOTA Foundation currently provides the following public load-balanced testne
   - Available routes: https://api.testnet.shimmer.network/api/routes
   - Health endpoint: https://api.testnet.shimmer.network/health
 - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
+- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
 These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
-
-## Developer Tools
-
-- [Explorer](https://explorer.shimmer.network)
-- [Online Faucet](https://faucet.testnet.shimmer.network)
-- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
-- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue

--- a/next/develop/endpoints/testnet.md
+++ b/next/develop/endpoints/testnet.md
@@ -16,7 +16,7 @@ Testnet is a pre-release of the Shimmer network that is currently under developm
 
 ## Public Infrastructure
 
-We currently provide load-balanced public testnet endpoints:
+The IOTA Foundation currently provides the following public load-balanced testnet endpoints:
 
 - Node API: https://api.testnet.shimmer.network
   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -221,6 +221,16 @@ module.exports = {
           type: 'link',
           href: '/smart-contracts/guide/wasm_vm/schema',
         },
+        {
+          label: 'Explorer',
+          type: 'link',
+          href: 'https://explorer.shimmer.network',
+        },
+        {
+          label: 'Testnet Faucet',
+          type: 'link',
+          href: 'https://faucet.testnet.shimmer.network',
+        }
       ],
     },
     {

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -184,18 +184,18 @@ module.exports = {
       type: 'category',
       label: 'Endpoints',
       collapsed: true,
-      items: [            
+      items: [
         {
           type: 'doc',
           id: 'endpoints/shimmer',
-          label: 'Mainnet'
+          label: 'Mainnet',
         },
         {
           type: 'doc',
           id: 'endpoints/testnet',
-          label: 'Devnet'
+          label: 'Devnet',
         },
-      ]
+      ],
     },
     {
       type: 'category',

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -230,7 +230,7 @@ module.exports = {
           label: 'Testnet Faucet',
           type: 'link',
           href: 'https://faucet.testnet.shimmer.network',
-        }
+        },
       ],
     },
     {

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -182,6 +182,23 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Endpoints',
+      collapsed: true,
+      items: [            
+        {
+          type: 'doc',
+          id: 'endpoints/mainnet',
+          label: 'Mainnet'
+        },
+        {
+          type: 'doc',
+          id: 'endpoints/devnet',
+          label: 'Devnet'
+        },
+      ]
+    },
+    {
+      type: 'category',
       label: 'Tools',
       link: {
         type: 'generated-index',

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -187,12 +187,12 @@ module.exports = {
       items: [            
         {
           type: 'doc',
-          id: 'endpoints/mainnet',
+          id: 'endpoints/shimmer',
           label: 'Mainnet'
         },
         {
           type: 'doc',
-          id: 'endpoints/devnet',
+          id: 'endpoints/testnet',
           label: 'Devnet'
         },
       ]

--- a/next/develop/sidebars.ts
+++ b/next/develop/sidebars.ts
@@ -188,12 +188,12 @@ module.exports = {
         {
           type: 'doc',
           id: 'endpoints/shimmer',
-          label: 'Mainnet',
+          label: 'Shimmer',
         },
         {
           type: 'doc',
           id: 'endpoints/testnet',
-          label: 'Devnet',
+          label: 'Testnet',
         },
       ],
     },

--- a/shimmer/develop/endpoints/shimmer.md
+++ b/shimmer/develop/endpoints/shimmer.md
@@ -15,7 +15,7 @@ keywords:
 
 ## Public Infrastructure
 
-The IOTA Foundation currently provides these public load-balanced Shimmer endpoints:
+The IOTA Foundation currently provides the following public load-balanced Shimmer endpoints:
 
 Node API: https://api.shimmer.network  
 Example info endpoint: https://api.shimmer.network/api/core/v2/info  

--- a/shimmer/develop/endpoints/shimmer.md
+++ b/shimmer/develop/endpoints/shimmer.md
@@ -24,4 +24,4 @@ Health endpoint: https://api.shimmer.network/health
 MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
 Chronicle API: https://chronicle.shimmer.network
 
-These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](/tips/tips/TIP-0025), [TIP-26](/tips/tips/TIP-0026) and [TIP-28](/tips/tips/TIP-0028)) over TLS

--- a/shimmer/develop/endpoints/shimmer.md
+++ b/shimmer/develop/endpoints/shimmer.md
@@ -25,7 +25,3 @@ MQTT: wss://api.shimmer.network:443/api/mqtt/v1
 Chronicle API: https://chronicle.shimmer.network
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
-
-## Developer Tools
-
-- [Explorer](https://explorer.shimmer.network).

--- a/shimmer/develop/endpoints/shimmer.md
+++ b/shimmer/develop/endpoints/shimmer.md
@@ -1,0 +1,30 @@
+---
+description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled. 
+image: /img/logo/preview.png
+keywords:
+- shimmer
+- MQTT
+- REST API
+- HTTP
+- Explorer
+- reference
+- Endpoints
+---
+# Shimmer
+
+## Public Infrastructure
+
+The IOTA Foundation currently provides these public load-balanced Shimmer endpoints:
+
+Node API: https://api.shimmer.network  
+Example info endpoint: https://api.shimmer.network/api/core/v2/info  
+Available routes: https://api.shimmer.network/api/routes  
+Health endpoint: https://api.shimmer.network/health  
+MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
+Chronicle API: https://chronicle.shimmer.network  
+
+These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
+
+## Developer Tools
+
+- [Explorer](https://explorer.shimmer.network).

--- a/shimmer/develop/endpoints/shimmer.md
+++ b/shimmer/develop/endpoints/shimmer.md
@@ -1,15 +1,16 @@
 ---
-description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled. 
+description: The IOTA foundation provides load-balanced public Shimmer endpoints where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
-- shimmer
-- MQTT
-- REST API
-- HTTP
-- Explorer
-- reference
-- Endpoints
+  - shimmer
+  - MQTT
+  - REST API
+  - HTTP
+  - Explorer
+  - reference
+  - Endpoints
 ---
+
 # Shimmer
 
 ## Public Infrastructure
@@ -21,7 +22,7 @@ Example info endpoint: https://api.shimmer.network/api/core/v2/info
 Available routes: https://api.shimmer.network/api/routes  
 Health endpoint: https://api.shimmer.network/health  
 MQTT: wss://api.shimmer.network:443/api/mqtt/v1  
-Chronicle API: https://chronicle.shimmer.network  
+Chronicle API: https://chronicle.shimmer.network
 
 These endpoints have MQTT (via WebSockets) exposed and offer the HTTP REST API (according to the specifications [TIP-25](https://github.com/iotaledger/tips/blob/main/tips/TIP-0025/tip-0025.md), [TIP-26](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md) and [TIP-28](https://github.com/iotaledger/tips/blob/main/tips/TIP-0028/tip-0028.md)) over TLS
 

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -27,4 +27,4 @@ The IOTA Foundation currently provides the following public load-balanced testne
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/rest-api/iota-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/core-rest-api/iota-core-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -12,7 +12,7 @@ keywords:
 
 # Public Testnet
 
-The testnet is the public infrastructure for developers. It runs on top of the beta releases of IOTA software and runs a faucet to easily get tokens for testing.
+The testnet is the public infrastructure for developers. It runs on top of the beta releases of IOTA software and runs a [faucet](https://faucet.testnet.shimmer.network) to easily get tokens for testing.
 
 ## Public Infrastructure
 
@@ -23,13 +23,8 @@ The IOTA Foundation currently provides the following public load-balanced testne
   - Available routes: https://api.testnet.shimmer.network/api/routes
   - Health endpoint: https://api.testnet.shimmer.network/health
 - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
+- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
 These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
-
-## Developer Tools
-
-- [Explorer](https://explorer.shimmer.network)
-- [Online Faucet](https://faucet.testnet.shimmer.network)
-- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
-- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -1,0 +1,37 @@
+---
+description: The IOTA foundation provides load-balanced public Shimmer Beta endpoints, where MQTT and the HTTP REST API are enabled.
+image: /img/logo/preview.png
+keywords:
+- devnet
+- load-balanced
+- HTTP REST API
+- MQTT
+- reference
+- Endpoints
+---
+# Shimmer Beta
+
+Shimmer Beta is a pre-release of the Shimmer network that is currently under development.
+
+## Public Infrastructure
+
+We currently provide load-balanced public Shimmer Beta endpoints:
+
+ - Node API: https://api.testnet.shimmer.network
+   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
+   - Available routes: https://api.testnet.shimmer.network/api/routes
+   - Health endpoint: https://api.testnet.shimmer.network/health
+ - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+ - Chronicle API: https://chronicle.testnet.shimmer.network
+
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+
+## Developer Tools
+
+- [Explorer](https://explorer.shimmer.network)
+- [Online Faucet](https://faucet.testnet.shimmer.network)
+- Faucet Info API: https://faucet.testnet.shimmer.network/api/info
+- Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
+- [Cli-Wallet](https://github.com/iotaledger/cli-wallet/tree/develop)
+- [shimmer-faucet code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet/tree/hornet)
+- [shimmer-faucet backend](https://github.com/iotaledger/inx-faucet)

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -10,9 +10,9 @@ keywords:
   - Endpoints
 ---
 
-# Testnet
+# Public Testnet
 
-Testnet is a pre-release of the Shimmer network that is currently under development.
+The testnet is the public infrastructure for developers. It runs on top of the beta releases of IOTA software and runs a faucet to easily get tokens for testing.
 
 ## Public Infrastructure
 

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -2,13 +2,14 @@
 description: The IOTA foundation provides load-balanced public testnet endpoints, where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
-- devnet
-- load-balanced
-- HTTP REST API
-- MQTT
-- reference
-- Endpoints
+  - devnet
+  - load-balanced
+  - HTTP REST API
+  - MQTT
+  - reference
+  - Endpoints
 ---
+
 # Testnet
 
 Testnet is a pre-release of the Shimmer network that is currently under development.
@@ -17,12 +18,12 @@ Testnet is a pre-release of the Shimmer network that is currently under developm
 
 We currently provide load-balanced public testnet endpoints:
 
- - Node API: https://api.testnet.shimmer.network
-   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
-   - Available routes: https://api.testnet.shimmer.network/api/routes
-   - Health endpoint: https://api.testnet.shimmer.network/health
- - MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
- - Chronicle API: https://chronicle.testnet.shimmer.network
+- Node API: https://api.testnet.shimmer.network
+  - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
+  - Available routes: https://api.testnet.shimmer.network/api/routes
+  - Health endpoint: https://api.testnet.shimmer.network/health
+- MQTT: wss://api.testnet.shimmer.network:443/api/mqtt/v1
+- Chronicle API: https://chronicle.testnet.shimmer.network
 
 These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
 

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -1,5 +1,5 @@
 ---
-description: The IOTA foundation provides load-balanced public Shimmer Beta endpoints, where MQTT and the HTTP REST API are enabled.
+description: The IOTA foundation provides load-balanced public testnet endpoints, where MQTT and the HTTP REST API are enabled.
 image: /img/logo/preview.png
 keywords:
 - devnet
@@ -9,13 +9,13 @@ keywords:
 - reference
 - Endpoints
 ---
-# Shimmer Beta
+# Testnet
 
-Shimmer Beta is a pre-release of the Shimmer network that is currently under development.
+Testnet is a pre-release of the Shimmer network that is currently under development.
 
 ## Public Infrastructure
 
-We currently provide load-balanced public Shimmer Beta endpoints:
+We currently provide load-balanced public testnet endpoints:
 
  - Node API: https://api.testnet.shimmer.network
    - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info
@@ -32,6 +32,3 @@ These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTT
 - [Online Faucet](https://faucet.testnet.shimmer.network)
 - Faucet Info API: https://faucet.testnet.shimmer.network/api/info
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
-- [Cli-Wallet](https://github.com/iotaledger/cli-wallet/tree/develop)
-- [shimmer-faucet code (nodejs + svelte)](https://github.com/iotaledger/chrysalis-faucet/tree/hornet)
-- [shimmer-faucet backend](https://github.com/iotaledger/inx-faucet)

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -27,4 +27,4 @@ The IOTA Foundation currently provides the following public load-balanced testne
 - Faucet Enqueue API: https://faucet.testnet.shimmer.network/api/enqueue
 - Chronicle API: https://chronicle.testnet.shimmer.network
 
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0025/core-rest-api.yaml), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.
+These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this specifications [TIP-25](nodes/rest-api/iota-rest-api.info.mdx), [TIP-26](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0026/indexer-rest-api.yaml) over TLS.

--- a/shimmer/develop/endpoints/testnet.md
+++ b/shimmer/develop/endpoints/testnet.md
@@ -16,7 +16,7 @@ Testnet is a pre-release of the Shimmer network that is currently under developm
 
 ## Public Infrastructure
 
-We currently provide load-balanced public testnet endpoints:
+The IOTA Foundation currently provides the following public load-balanced testnet endpoints:
 
 - Node API: https://api.testnet.shimmer.network
   - Example info endpoint: https://api.testnet.shimmer.network/api/core/v2/info

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -221,6 +221,16 @@ module.exports = {
           type: 'link',
           href: '/smart-contracts/guide/wasm_vm/schema',
         },
+        {
+          label: 'Explorer',
+          type: 'link',
+          href: 'https://explorer.shimmer.network',
+        },
+        {
+          label: 'Testnet Faucet',
+          type: 'link',
+          href: 'https://faucet.testnet.shimmer.network',
+        }
       ],
     },
     {

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -184,18 +184,18 @@ module.exports = {
       type: 'category',
       label: 'Endpoints',
       collapsed: true,
-      items: [            
+      items: [
         {
           type: 'doc',
           id: 'endpoints/shimmer',
-          label: 'Mainnet'
+          label: 'Mainnet',
         },
         {
           type: 'doc',
           id: 'endpoints/testnet',
-          label: 'Devnet'
+          label: 'Devnet',
         },
-      ]
+      ],
     },
     {
       type: 'category',

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -230,7 +230,7 @@ module.exports = {
           label: 'Testnet Faucet',
           type: 'link',
           href: 'https://faucet.testnet.shimmer.network',
-        }
+        },
       ],
     },
     {

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -182,6 +182,23 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Endpoints',
+      collapsed: true,
+      items: [            
+        {
+          type: 'doc',
+          id: 'endpoints/mainnet',
+          label: 'Mainnet'
+        },
+        {
+          type: 'doc',
+          id: 'endpoints/devnet',
+          label: 'Devnet'
+        },
+      ]
+    },
+    {
+      type: 'category',
       label: 'Tools',
       link: {
         type: 'generated-index',

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -187,12 +187,12 @@ module.exports = {
       items: [            
         {
           type: 'doc',
-          id: 'endpoints/mainnet',
+          id: 'endpoints/shimmer',
           label: 'Mainnet'
         },
         {
           type: 'doc',
-          id: 'endpoints/devnet',
+          id: 'endpoints/testnet',
           label: 'Devnet'
         },
       ]

--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -188,12 +188,12 @@ module.exports = {
         {
           type: 'doc',
           id: 'endpoints/shimmer',
-          label: 'Mainnet',
+          label: 'Shimmer',
         },
         {
           type: 'doc',
           id: 'endpoints/testnet',
-          label: 'Devnet',
+          label: 'Testnet',
         },
       ],
     },


### PR DESCRIPTION
# Description of change

This PR moved the endpoint docs from the introduction docs (for example https://wiki.iota.org/introduction/reference/networks/mainnet/) to the `Develop` section of the wiki.

## Links to any relevant issues

https://github.com/iotaledger/introduction-docs/issues/152

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
