### PR TITLE
Temporarily disable cookiebot

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,8 @@ const production = {
     },
   },
   plugins: [
-    path.resolve(__dirname, 'plugins', 'cookiebot'),
+    // Temporarily disabled because of Cookiebot blocking required scripts.
+    // path.resolve(__dirname, 'plugins', 'cookiebot'),
     path.resolve(__dirname, 'plugins', 'matomo'),
     [
       '@docusaurus/plugin-google-gtag',


### PR DESCRIPTION
# Description of change

Temporarily disable cookiebot, because it blocks some scripts required by Docusaurus to work correctly. This happens when you decline cookies.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code, particularly in hard-to-understand areas
