### PR TITLE
Add rehype-lodash-template to use template strings

### DIFF
--- a/iota/docusaurus.config.js
+++ b/iota/docusaurus.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-async function createConfig() {
+module.exports = async () => {
   const rehype_lodash_template = (await import('rehype-lodash-template')).default;
 
   return {
@@ -290,5 +290,3 @@ async function createConfig() {
     ],
   };
 }
-
-module.exports = createConfig;

--- a/iota/docusaurus.config.js
+++ b/iota/docusaurus.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 
 module.exports = async () => {
-  const rehype_lodash_template = (await import('rehype-lodash-template')).default;
+  const rehype_lodash_template = (await import('rehype-lodash-template'))
+    .default;
 
   return {
     title: 'IOTA Wiki',
@@ -229,7 +230,7 @@ module.exports = async () => {
                 values: {
                   network: 'IOTA',
                 },
-              }
+              },
             ],
           ],
           showLastUpdateTime: true,
@@ -289,4 +290,4 @@ module.exports = async () => {
       ],
     ],
   };
-}
+};

--- a/iota/docusaurus.config.js
+++ b/iota/docusaurus.config.js
@@ -1,280 +1,294 @@
 const path = require('path');
 
-module.exports = {
-  title: 'IOTA Wiki',
-  tagline: 'The complete reference for IOTA',
-  baseUrl: '/',
-  themeConfig: {
-    announcementBar: {
-      id: 'govern',
-      content:
-        'If you would like to get more involved in the future governance of Shimmer, IOTA, and the Assembly network, join the discussions with the community in our <a target="_blank" href="https://govern.iota.org">governance forum</a> 🏛️',
-      backgroundColor: '#5991c7',
-      textColor: '#ffffff',
-      isCloseable: true,
-    },
-    image: 'img/iota-wiki.png',
-    navbar: {
-      hideOnScroll: true,
-      logo: {
-        alt: 'IOTA Wiki Logo',
-        src: 'img/logo.svg',
-        srcDark: 'img/logo_dark.svg',
+async function createConfig() {
+  const rehype_lodash_template = (await import('rehype-lodash-template')).default;
+
+  return {
+    title: 'IOTA Wiki',
+    tagline: 'The complete reference for IOTA',
+    baseUrl: '/',
+    themeConfig: {
+      announcementBar: {
+        id: 'govern',
+        content:
+          'If you would like to get more involved in the future governance of Shimmer, IOTA, and the Assembly network, join the discussions with the community in our <a target="_blank" href="https://govern.iota.org">governance forum</a> 🏛️',
+        backgroundColor: '#5991c7',
+        textColor: '#ffffff',
+        isCloseable: true,
       },
-      items: [
+      image: 'img/iota-wiki.png',
+      navbar: {
+        hideOnScroll: true,
+        logo: {
+          alt: 'IOTA Wiki Logo',
+          src: 'img/logo.svg',
+          srcDark: 'img/logo_dark.svg',
+        },
+        items: [
+          {
+            label: 'Use IOTA',
+            to: '/use/wallets/what-is-a-wallet',
+            activeBaseRegex: '^(/[^/]+)?/use/.*',
+          },
+          {
+            label: 'Learn',
+            to: '/learn/about-iota/an-introduction-to-iota',
+            activeBaseRegex:
+              '^(/[^/]+)?/learn/.*|' +
+              '^(/[^/]+)?/IOTA-2.0-Research-Specifications/.*|' +
+              '^(/[^/]+)?/goshimmer/.*',
+          },
+          {
+            label: 'Develop',
+            to: '/develop/welcome',
+            activeBaseRegex:
+              '^(/[^/]+)?/develop.*|' +
+              '^(/[^/]+)?/identity.rs/.*|' +
+              '^(/[^/]+)?/iota.rs/.*|' +
+              '^(/[^/]+)?/wallet.rs/.*|' +
+              '^(/[^/]+)?/streams/.*|' +
+              '^(/[^/]+)?/stronghold.rs/.*|' +
+              '^(/[^/]+)?/hornet/.*|' +
+              '^(/[^/]+)?/bee/.*|' +
+              '^(/[^/]+)?/chronicle/.*|' +
+              '^(/[^/]+)?/introduction/.*|' +
+              '^(/[^/]+)?/integration-services/.*|' +
+              '^(/[^/]+)?/tutorials*',
+          },
+          {
+            label: 'Community',
+            to: '/community/the-community/discord',
+            activeBaseRegex: '^(/[^/]+)?/community/.*',
+          },
+          {
+            type: 'custom-network-dropdown',
+            position: 'right',
+            label: 'IOTA',
+            items: [
+              {
+                label: 'Shimmer',
+                routeBasePath: '/shimmer/',
+              },
+              {
+                label: 'Next',
+                routeBasePath: '/next/',
+              },
+            ],
+          },
+        ],
+      },
+      footer: {
+        links: [
+          {
+            title: 'Use',
+            items: [
+              {
+                label: 'Wallets',
+                to: '/use/wallets/what-is-a-wallet',
+              },
+            ],
+          },
+          {
+            title: 'Learn',
+            items: [
+              {
+                label: 'How It Works',
+                to: '/learn/about-iota/an-introduction-to-iota',
+              },
+              {
+                label: 'IOTA Token',
+                to: '/learn/iota-token/buying-iota',
+              },
+              {
+                label: 'Research',
+                to: '/learn/research/research-outline',
+              },
+              {
+                label: 'Glossary',
+                to: '/learn/glossary',
+              },
+              {
+                label: 'FAQs',
+                to: '/learn/faqs',
+              },
+            ],
+          },
+          {
+            title: 'Develop',
+            items: [
+              {
+                label: 'Nodes',
+                to: '/develop/nodes/about-nodes',
+              },
+              {
+                label: 'Chronicle',
+                href: '/chronicle/welcome',
+              },
+              {
+                label: 'Tutorials',
+                href: '/tutorials',
+              },
+            ],
+          },
+          {
+            title: 'Community',
+            items: [
+              {
+                label: 'Funding',
+                to: '/community/funding/edf-funding',
+              },
+              {
+                label: 'The Community',
+                to: '/community/the-community/how-to-support',
+              },
+              {
+                label: 'Research',
+                to: '/community/research/research-outline',
+              },
+              {
+                label: 'Contribute To Wiki',
+                to: '/community/contribute-to-wiki/welcome',
+              },
+            ],
+          },
+        ],
+        logo: {
+          alt: 'IOTA Logo',
+          src: 'img/footer_logo.svg',
+          href: 'https://www.iota.org',
+        },
+        copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus. <a href="/cookie-policy"> Cookie Policy. </a>`,
+      },
+      socials: [
         {
-          label: 'Use IOTA',
-          to: '/use/wallets/what-is-a-wallet',
-          activeBaseRegex: '^(/[^/]+)?/use/.*',
+          url: 'https://www.youtube.com/c/iotafoundation',
+          backgroundColor: 'var(--ifm-color-gray-900)',
         },
         {
-          label: 'Learn',
-          to: '/learn/about-iota/an-introduction-to-iota',
-          activeBaseRegex:
-            '^(/[^/]+)?/learn/.*|' +
-            '^(/[^/]+)?/IOTA-2.0-Research-Specifications/.*|' +
-            '^(/[^/]+)?/goshimmer/.*',
+          url: 'https://www.github.com/iotaledger/',
+          backgroundColor: '#2C3850',
         },
         {
-          label: 'Develop',
-          to: '/develop/welcome',
-          activeBaseRegex:
-            '^(/[^/]+)?/develop.*|' +
-            '^(/[^/]+)?/identity.rs/.*|' +
-            '^(/[^/]+)?/iota.rs/.*|' +
-            '^(/[^/]+)?/wallet.rs/.*|' +
-            '^(/[^/]+)?/streams/.*|' +
-            '^(/[^/]+)?/stronghold.rs/.*|' +
-            '^(/[^/]+)?/hornet/.*|' +
-            '^(/[^/]+)?/bee/.*|' +
-            '^(/[^/]+)?/chronicle/.*|' +
-            '^(/[^/]+)?/introduction/.*|' +
-            '^(/[^/]+)?/integration-services/.*|' +
-            '^(/[^/]+)?/tutorials*',
+          url: 'https://discord.iota.org/',
+          backgroundColor: '#4B576F',
         },
         {
-          label: 'Community',
-          to: '/community/the-community/discord',
-          activeBaseRegex: '^(/[^/]+)?/community/.*',
+          url: 'https://www.twitter.com/iota/',
+          backgroundColor: '#6A768E',
         },
         {
-          type: 'custom-network-dropdown',
-          position: 'right',
-          label: 'IOTA',
-          items: [
-            {
-              label: 'Shimmer',
-              routeBasePath: '/shimmer/',
-            },
-            {
-              label: 'Next',
-              routeBasePath: '/next/',
-            },
-          ],
+          url: 'https://www.reddit.com/r/iota/',
+          backgroundColor: '#7D89A1',
+        },
+        {
+          url: 'https://www.linkedin.com/company/iotafoundation/',
+          backgroundColor: '#8995AD',
+        },
+        {
+          url: 'https://www.instagram.com/iotafoundation/',
+          backgroundColor: '#99A5BD',
         },
       ],
     },
-    footer: {
-      links: [
+    presets: [
+      [
+        '@docusaurus/preset-classic',
         {
-          title: 'Use',
-          items: [
-            {
-              label: 'Wallets',
-              to: '/use/wallets/what-is-a-wallet',
-            },
-          ],
-        },
-        {
-          title: 'Learn',
-          items: [
-            {
-              label: 'How It Works',
-              to: '/learn/about-iota/an-introduction-to-iota',
-            },
-            {
-              label: 'IOTA Token',
-              to: '/learn/iota-token/buying-iota',
-            },
-            {
-              label: 'Research',
-              to: '/learn/research/research-outline',
-            },
-            {
-              label: 'Glossary',
-              to: '/learn/glossary',
-            },
-            {
-              label: 'FAQs',
-              to: '/learn/faqs',
-            },
-          ],
-        },
-        {
-          title: 'Develop',
-          items: [
-            {
-              label: 'Nodes',
-              to: '/develop/nodes/about-nodes',
-            },
-            {
-              label: 'Chronicle',
-              href: '/chronicle/welcome',
-            },
-            {
-              label: 'Tutorials',
-              href: '/tutorials',
-            },
-          ],
-        },
-        {
-          title: 'Community',
-          items: [
-            {
-              label: 'Funding',
-              to: '/community/funding/edf-funding',
-            },
-            {
-              label: 'The Community',
-              to: '/community/the-community/how-to-support',
-            },
-            {
-              label: 'Research',
-              to: '/community/research/research-outline',
-            },
-            {
-              label: 'Contribute To Wiki',
-              to: '/community/contribute-to-wiki/welcome',
-            },
-          ],
+          docs: false,
+          blog: false,
+          theme: {
+            customCss: require.resolve('../src/iota/css/custom.css'),
+          },
+          sitemap: {
+            changefreq: 'daily',
+            priority: 0.5,
+          },
+          pages: {
+            path: path.resolve(__dirname, '../src/iota/pages'),
+          },
         },
       ],
-      logo: {
-        alt: 'IOTA Logo',
-        src: 'img/footer_logo.svg',
-        href: 'https://www.iota.org',
-      },
-      copyright: `© ${new Date().getFullYear()} IOTA Wiki. Built with Docusaurus. <a href="/cookie-policy"> Cookie Policy. </a>`,
-    },
-    socials: [
-      {
-        url: 'https://www.youtube.com/c/iotafoundation',
-        backgroundColor: 'var(--ifm-color-gray-900)',
-      },
-      {
-        url: 'https://www.github.com/iotaledger/',
-        backgroundColor: '#2C3850',
-      },
-      {
-        url: 'https://discord.iota.org/',
-        backgroundColor: '#4B576F',
-      },
-      {
-        url: 'https://www.twitter.com/iota/',
-        backgroundColor: '#6A768E',
-      },
-      {
-        url: 'https://www.reddit.com/r/iota/',
-        backgroundColor: '#7D89A1',
-      },
-      {
-        url: 'https://www.linkedin.com/company/iotafoundation/',
-        backgroundColor: '#8995AD',
-      },
-      {
-        url: 'https://www.instagram.com/iotafoundation/',
-        backgroundColor: '#99A5BD',
-      },
     ],
-  },
-  presets: [
-    [
-      '@docusaurus/preset-classic',
-      {
-        docs: false,
-        blog: false,
-        theme: {
-          customCss: require.resolve('../src/iota/css/custom.css'),
-        },
-        sitemap: {
-          changefreq: 'daily',
-          priority: 0.5,
-        },
-        pages: {
-          path: path.resolve(__dirname, '../src/iota/pages'),
-        },
-      },
-    ],
-  ],
-  plugins: [
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'use',
-        path: path.resolve(__dirname, 'use'),
-        routeBasePath: 'use',
-        sidebarPath: require.resolve('./use/sidebars.ts'),
+    plugins: [
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'use',
+          path: path.resolve(__dirname, 'use'),
+          routeBasePath: 'use',
+          sidebarPath: require.resolve('./use/sidebars.ts'),
 
-        // General config
-        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
-        remarkPlugins: [
-          require('remark-code-import'),
-          require('remark-import-partial'),
-        ],
-        showLastUpdateTime: true,
-      },
-    ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'learn',
-        path: path.resolve(__dirname, 'learn'),
-        routeBasePath: 'learn',
-        sidebarPath: require.resolve('./learn/sidebars.ts'),
+          // General config
+          editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
+          remarkPlugins: [
+            require('remark-code-import'),
+            require('remark-import-partial'),
+            [
+              rehype_lodash_template,
+              {
+                values: {
+                  network: 'IOTA',
+                },
+              }
+            ],
+          ],
+          showLastUpdateTime: true,
+        },
+      ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'learn',
+          path: path.resolve(__dirname, 'learn'),
+          routeBasePath: 'learn',
+          sidebarPath: require.resolve('./learn/sidebars.ts'),
 
-        // General config
-        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
-        remarkPlugins: [
-          require('remark-code-import'),
-          require('remark-import-partial'),
-        ],
-        showLastUpdateTime: true,
-      },
-    ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'develop',
-        path: path.resolve(__dirname, 'develop'),
-        routeBasePath: 'develop',
-        sidebarPath: require.resolve('./develop/sidebars.ts'),
-        docItemComponent: '@theme/ApiItem',
+          // General config
+          editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
+          remarkPlugins: [
+            require('remark-code-import'),
+            require('remark-import-partial'),
+          ],
+          showLastUpdateTime: true,
+        },
+      ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'develop',
+          path: path.resolve(__dirname, 'develop'),
+          routeBasePath: 'develop',
+          sidebarPath: require.resolve('./develop/sidebars.ts'),
+          docItemComponent: '@theme/ApiItem',
 
-        // General config
-        editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
-        remarkPlugins: [
-          require('remark-code-import'),
-          require('remark-import-partial'),
-        ],
-        showLastUpdateTime: true,
-      },
-    ],
-    [
-      'docusaurus-plugin-openapi-docs',
-      {
-        id: 'openapi',
-        docsPluginId: 'develop', // e.g. "classic" or the plugin-content-docs id
-        config: {
-          rest_api: {
-            specPath:
-              'https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0013/rest-api.yaml',
-            outputDir: path.resolve(__dirname, 'develop/nodes/rest-api'),
-            sidebarOptions: {
-              groupPathsBy: 'tag',
+          // General config
+          editUrl: 'https://github.com/iota-wiki/iota-wiki/edit/main/',
+          remarkPlugins: [
+            require('remark-code-import'),
+            require('remark-import-partial'),
+          ],
+          showLastUpdateTime: true,
+        },
+      ],
+      [
+        'docusaurus-plugin-openapi-docs',
+        {
+          id: 'openapi',
+          docsPluginId: 'develop', // e.g. "classic" or the plugin-content-docs id
+          config: {
+            rest_api: {
+              specPath:
+                'https://raw.githubusercontent.com/iotaledger/tips/main/tips/TIP-0013/rest-api.yaml',
+              outputDir: path.resolve(__dirname, 'develop/nodes/rest-api'),
+              sidebarOptions: {
+                groupPathsBy: 'tag',
+              },
             },
           },
         },
-      },
+      ],
     ],
-  ],
-};
+  };
+}
+
+module.exports = createConfig;

--- a/iota/use/wallets/what-is-a-wallet.md
+++ b/iota/use/wallets/what-is-a-wallet.md
@@ -8,7 +8,7 @@ description: A wallet helps you to securely store and handle your Tokens. We
 
 ![Wallets](/img/Banner/banner_wallets.svg)
 
-A wallet is a tool that gives you access to your IOTA tokens. One very important fact that you need to understand from the beginning is **your IOTA tokens are never stored INSIDE a wallet**.
+A wallet is a tool that gives you access to your ${network} tokens. One very important fact that you need to understand from the beginning is **your IOTA tokens are never stored INSIDE a wallet**.
 
 This is a common misunderstanding. All your IOTA tokens only exist in the Tangle network and cannot leave this network. So you do not physically “store” them “inside” anything.
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-popper": "^2.3.0",
     "react-select": "^5.2.2",
     "rehype-katex": "4",
+    "rehype-lodash-template": "^0.2.1",
     "remark-code-import": "^0.3.0",
     "remark-import-partial": "^0.0.2",
     "remark-math": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,7 @@ __metadata:
     react-popper: ^2.3.0
     react-select: ^5.2.2
     rehype-katex: 4
+    rehype-lodash-template: ^0.2.1
     remark-code-import: ^0.3.0
     remark-import-partial: ^0.0.2
     remark-math: ^3.0.1
@@ -3559,6 +3560,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: e009a2bfb50e90ca9b7c6e8f648f8464067271fd99116f881073fa6fa76dc8d0133181dd65e6614d5fb1220d671d67b0124aef7d97dc02d7e342ab143a47779d
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.191":
+  version: 4.14.192
+  resolution: "@types/lodash@npm:4.14.192"
+  checksum: 31e1f0543a04158d2c429c45efd7c77882736630d0652f82eb337d6159ec0c249c5d175c0af731537b53271e665ff8d76f43221d75d03646d31cb4bd6f0056b1
   languageName: node
   linkType: hard
 
@@ -10022,6 +10030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash._reinterpolate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lodash._reinterpolate@npm:3.0.0"
+  checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -10068,6 +10083,25 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.template@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.template@npm:4.5.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+    lodash.templatesettings: ^4.0.0
+  checksum: ca64e5f07b6646c9d3dbc0fe3aaa995cb227c4918abd1cef7a9024cd9c924f2fa389a0ec4296aa6634667e029bc81d4bbdb8efbfde11df76d66085e6c529b450
+  languageName: node
+  linkType: hard
+
+"lodash.templatesettings@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "lodash.templatesettings@npm:4.2.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+  checksum: 863e025478b092997e11a04e9d9e735875eeff1ffcd6c61742aa8272e3c2cddc89ce795eb9726c4e74cef5991f722897ff37df7738a125895f23fc7d12a7bb59
   languageName: node
   linkType: hard
 
@@ -13607,6 +13641,17 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
     unified: ^9.0.0
     unist-util-visit: ^2.0.0
   checksum: 974670a12f327b2fab447e16b9db5c2bdcf2d632a40d2123380696eb976fdeb73165376fe79dfd667667969930071275d567c0abc2802570d3bba1023578ad35
+  languageName: node
+  linkType: hard
+
+"rehype-lodash-template@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "rehype-lodash-template@npm:0.2.1"
+  dependencies:
+    "@types/lodash": ^4.14.191
+    lodash.template: ^4.5.0
+    unist-util-visit-parents: ^5.1.1
+  checksum: 0a30ded80d2e05ce4eaf4aecc1c19ea3ebedfef4adab384c1db4c92b196dbfb21ce90aeb475fa5e7da20709f1a866cc4913266b72e988f622800fda66bcf18ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description of change

This should make it possible to use template strings like `${network}` for easier management of different versions of our docs

## Links to any relevant issues

Fixes #879 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
