### PR TITLE
Prevent preview deploy when Dependabot PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,6 +19,7 @@ jobs:
   config:
     uses: ./.github/workflows/config.reusable.yaml
   deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
# Description of change

This prevents workflows from trying to deploy a preview for Dependabot PRs, because they are unnecessary and block the future potential of auto-merging these PRs. Other checks and the complete Wiki builds are still done, to verify the PRs don't break anything, just the preview is never deployed to Vercel. See the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) for reference.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
