### PR TITLE
fix: wrap desktop dropdown link in BrowserOnly component

### DIFF
--- a/src/common/components/CustomNetworkDropdown/index.tsx
+++ b/src/common/components/CustomNetworkDropdown/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { renderToString } from 'react-dom/server';
 import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import { useLocation } from '@docusaurus/router';
 import { useCollapsible, Collapsible } from '@docusaurus/theme-common';
 import NavbarNavLink from '@theme/NavbarItem/NavbarNavLink';
@@ -86,29 +87,32 @@ function NetworkDropdownNavbarItemDesktop({
       </NavbarNavLink>
       <ul className='dropdown__menu'>
         {items.map((childItemProps, i) => (
-          <NavbarItem
-            isDropdownItem
-            onKeyDown={(e) => {
-              if (i === items.length - 1 && e.key === 'Tab') {
-                e.preventDefault();
-                setShowDropdown(false);
-                const nextNavbarItem =
-                  dropdownRef.current?.nextElementSibling ?? null;
-                if (nextNavbarItem) {
-                  const targetItem =
-                    nextNavbarItem instanceof HTMLAnchorElement
-                      ? nextNavbarItem
-                      : // Next item is another dropdown; focus on the inner
-                        // anchor element instead so there's outline
-                        nextNavbarItem.querySelector('a');
-                  targetItem.focus();
-                }
-              }
-            }}
-            activeClassName='dropdown__link--active'
-            {...childItemProps}
-            key={i}
-          />
+          <BrowserOnly key={i}>
+            {() => (
+              <NavbarItem
+                isDropdownItem
+                onKeyDown={(e) => {
+                  if (i === items.length - 1 && e.key === 'Tab') {
+                    e.preventDefault();
+                    setShowDropdown(false);
+                    const nextNavbarItem =
+                      dropdownRef.current?.nextElementSibling ?? null;
+                    if (nextNavbarItem) {
+                      const targetItem =
+                        nextNavbarItem instanceof HTMLAnchorElement
+                          ? nextNavbarItem
+                          : // Next item is another dropdown; focus on the inner
+                            // anchor element instead so there's outline
+                            nextNavbarItem.querySelector('a');
+                      targetItem.focus();
+                    }
+                  }
+                }}
+                activeClassName='dropdown__link--active'
+                {...childItemProps}
+              />
+            )}
+          </BrowserOnly>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
# Description of change

Wrap the desktop `dropdown link` in a BrowserOnly component to avoid 404 redirections.

## Links to any relevant issues

Fixes #806 

## Type of change

- Bug fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have commented my code, particularly in hard-to-understand areas
