### PR TITLE
Fix default wasp version

### DIFF
--- a/config/versionedConfig.js
+++ b/config/versionedConfig.js
@@ -28,11 +28,10 @@ exports.buildPluginsConfig = [
     versions: [
       {
         label: 'v1.5',
-        badges: ['Testnet'],
+        badges: ['IOTA', 'Shimmer', 'Testnet'],
       },
       {
         label: 'v1.6',
-        badges: ['IOTA', 'Shimmer'],
       },
     ],
   },
@@ -146,11 +145,10 @@ exports.maintainPluginsConfig = [
     versions: [
       {
         label: 'v1.5',
-        badges: ['Testnet'],
+        badges: ['IOTA', 'Shimmer', 'Testnet'],
       },
       {
         label: 'v1.6',
-        badges: ['IOTA', 'Shimmer'],
       },
     ],
   },


### PR DESCRIPTION
# Description of change

Currently we run 1.5 everywhere. So this is just a quick fix to make that the default docs showing up

